### PR TITLE
Make navbar hide/show snappier on landing page

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -48,11 +48,12 @@ export default function Navbar({ darkMode, toggleDarkMode, navigateTo, activePag
   const hidden = isHome && scrolled
 
   return (
-    <motion.nav
-      initial={{ y: -80, opacity: 0 }}
-      animate={{ y: hidden ? -80 : 0, opacity: hidden ? 0 : 1 }}
-      transition={{ duration: 0.4, ease: 'easeOut' }}
-      className={`fixed top-0 left-0 right-0 z-50 transition-all duration-400 ${
+    <nav
+      style={{
+        transform: hidden ? 'translateY(-100%)' : 'translateY(0)',
+        willChange: 'transform',
+      }}
+      className={`fixed top-0 left-0 right-0 z-50 transition-[transform,background-color,box-shadow] duration-200 ease-out motion-reduce:transition-none ${
         solid
           ? 'bg-white/95 dark:bg-gray-950/95 backdrop-blur-xl shadow-lg shadow-black/5 dark:shadow-black/30'
           : 'bg-transparent'
@@ -210,6 +211,6 @@ export default function Navbar({ darkMode, toggleDarkMode, navigateTo, activePag
           </motion.div>
         )}
       </AnimatePresence>
-    </motion.nav>
+    </nav>
   )
 }


### PR DESCRIPTION
## Summary
- Replaced framer-motion `animate` on the navbar root with a hardware-accelerated CSS transform
- 200ms transform transition removes the perceived lag when scrolling

https://claude.ai/code/session_01NZgkgCbLLfUUdwHC9m9HAQ