### PR TITLE
Replace navbar on landing page with dark mode toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, lazy, Suspense } from 'react'
 import { Routes, Route, useLocation, useNavigate } from 'react-router-dom'
 import { motion, AnimatePresence } from 'framer-motion'
-import { ArrowUp } from 'lucide-react'
+import { ArrowUp, Moon, Sun } from 'lucide-react'
 import Navbar from './components/Navbar'
 import Hero from './components/Hero'
 import Footer from './components/Footer'
@@ -75,12 +75,22 @@ export default function App() {
 
   return (
     <div className="relative min-h-screen bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100 transition-colors duration-300">
-      <Navbar
-        darkMode={darkMode}
-        toggleDarkMode={() => setDarkMode(d => !d)}
-        navigateTo={navigateTo}
-        activePage={isHome ? 'home' : location.pathname.slice(1)}
-      />
+      {isHome ? (
+        <button
+          onClick={() => setDarkMode(d => !d)}
+          className="fixed top-4 right-4 sm:top-6 sm:right-6 z-50 p-2.5 rounded-xl text-white/80 hover:text-white hover:bg-white/10 transition-colors"
+          aria-label="Dark mode umschalten"
+        >
+          {darkMode ? <Sun size={18} /> : <Moon size={18} />}
+        </button>
+      ) : (
+        <Navbar
+          darkMode={darkMode}
+          toggleDarkMode={() => setDarkMode(d => !d)}
+          navigateTo={navigateTo}
+          activePage={location.pathname.slice(1)}
+        />
+      )}
 
       <AnimatePresence mode="wait">
         <motion.div

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react'
+import {useState} from 'react'
 import {AnimatePresence, motion} from 'framer-motion'
 import {ChevronLeft, Menu, Moon, Sun, X} from 'lucide-react'
 
@@ -26,38 +26,19 @@ const SECTION_LABELS: Record<string, string> = {
 }
 
 export default function Navbar({ darkMode, toggleDarkMode, navigateTo, activePage }: NavbarProps) {
-  const [scrolled, setScrolled] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
   const isHome = activePage === 'home'
-
-  useEffect(() => {
-    const onScroll = () => setScrolled(window.scrollY > 60)
-    window.addEventListener('scroll', onScroll, { passive: true })
-    return () => window.removeEventListener('scroll', onScroll)
-  }, [])
-
 
   const handleNav = (id: string) => {
     navigateTo(id)
     setMenuOpen(false)
   }
 
-  // Navbar is always solid when on a section page; transparent on home when not scrolled
-  const solid = !isHome || scrolled
-  // Hide the navbar while scrolled on the landing page; always show on other pages
-  const hidden = isHome && scrolled
+  const solid = true
 
   return (
     <nav
-      style={{
-        transform: hidden ? 'translateY(-100%)' : 'translateY(0)',
-        willChange: 'transform',
-      }}
-      className={`fixed top-0 left-0 right-0 z-50 transition-[transform,background-color,box-shadow] duration-200 ease-out motion-reduce:transition-none ${
-        solid
-          ? 'bg-white/95 dark:bg-gray-950/95 backdrop-blur-xl shadow-lg shadow-black/5 dark:shadow-black/30'
-          : 'bg-transparent'
-      }`}
+      className="fixed top-0 left-0 right-0 z-50 bg-white/95 dark:bg-gray-950/95 backdrop-blur-xl shadow-lg shadow-black/5 dark:shadow-black/30"
     >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">


### PR DESCRIPTION
## Summary
- Landing page no longer renders the full navbar
- Adds a single fixed top-right light/dark mode toggle on the landing page
- Section pages keep the navbar
- Cleaned up the now-unused scroll listener / hide logic in Navbar

https://claude.ai/code/session_01NZgkgCbLLfUUdwHC9m9HAQ