### PR TITLE
Anchor landing page dark mode toggle to the top

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,7 +78,7 @@ export default function App() {
       {isHome ? (
         <button
           onClick={() => setDarkMode(d => !d)}
-          className="fixed top-4 right-4 sm:top-6 sm:right-6 z-50 p-2.5 rounded-xl text-white/80 hover:text-white hover:bg-white/10 transition-colors"
+          className="absolute top-4 right-4 sm:top-6 sm:right-6 z-50 p-2.5 rounded-xl text-white/80 hover:text-white hover:bg-white/10 transition-colors"
           aria-label="Dark mode umschalten"
         >
           {darkMode ? <Sun size={18} /> : <Moon size={18} />}


### PR DESCRIPTION
## Summary
- Switched the landing-page toggle from `fixed` to `absolute` so it stays at the top of the page and scrolls away with the hero

https://claude.ai/code/session_01NZgkgCbLLfUUdwHC9m9HAQ