### PR TITLE
Cap Abgeordneter sheet portrait height in mobile landscape

### DIFF
--- a/src/components/sections/Partei.tsx
+++ b/src/components/sections/Partei.tsx
@@ -306,7 +306,7 @@ export default function Partei() {
                 <img
                   src={selectedPerson.bildUrl}
                   alt={selectedPerson.name}
-                  className="w-full block"
+                  className="w-full block landscape:max-h-[55vh] landscape:object-cover landscape:object-top sm:landscape:max-h-none"
                 />
               ) : (
                 <div className="w-full aspect-square bg-linear-to-br from-spd-red to-spd-red-dark flex items-center justify-center">


### PR DESCRIPTION
## Summary
- The Partei detail sheet's portrait image was rendered at `w-full` and natural aspect, so on landscape phones it filled almost the entire viewport
- Caps the image at 55vh in landscape orientation and uses `object-cover object-top` so the face stays visible while the name and contact info become reachable
- Constraint is removed at the `sm:` breakpoint so tablets/desktops keep the original full-portrait look

https://claude.ai/code/session_01NZgkgCbLLfUUdwHC9m9HAQ