### PR TITLE
Admin: review fixes, mobile UX polish, per-change revert

### DIFF
--- a/src/admin/components/ChangeList.tsx
+++ b/src/admin/components/ChangeList.tsx
@@ -1,0 +1,177 @@
+import {useMemo, useState} from 'react'
+import {AnimatePresence, motion} from 'framer-motion'
+import {ArrowRight, ChevronDown, History, Plus, Trash2, Undo2} from 'lucide-react'
+import type {TabConfig} from '../types'
+import {useAdminStore} from '../store'
+import {diffTab, summarizeValue, type ChangeEntry} from '../lib/diff'
+
+interface Props {
+    tab: TabConfig
+}
+
+export default function ChangeList({tab}: Props) {
+    const state = useAdminStore(s => s.state[tab.key])
+    const original = useAdminStore(s => s.originalState[tab.key])
+    const revertChange = useAdminStore(s => s.revertChange)
+    const [open, setOpen] = useState(false)
+
+    const entries = useMemo(() => diffTab(tab, original, state), [tab, original, state])
+
+    if (entries.length === 0) return null
+
+    // Group by (group + item) so multiple field edits on the same item collapse together
+    const groups = groupEntries(entries)
+
+    return (
+        <div className="mb-6">
+            <button
+                type="button"
+                onClick={() => setOpen(v => !v)}
+                className="w-full flex items-center gap-3 px-4 py-3 rounded-2xl bg-gradient-to-r from-amber-50/80 to-amber-50/40 dark:from-amber-900/20 dark:to-amber-900/5 border border-amber-200/60 dark:border-amber-800/40 hover:from-amber-50 hover:to-amber-50/60 dark:hover:from-amber-900/30 transition-all group"
+            >
+                <div className="w-8 h-8 rounded-xl bg-amber-100 dark:bg-amber-900/40 flex items-center justify-center shrink-0">
+                    <History size={14} className="text-amber-600 dark:text-amber-400"/>
+                </div>
+                <div className="flex-1 min-w-0 text-left">
+                    <div className="text-xs font-bold text-amber-800 dark:text-amber-200 flex items-center gap-2">
+                        Ungespeicherte Änderungen
+                        <span className="text-[10px] font-bold bg-amber-200/80 dark:bg-amber-800/60 text-amber-800 dark:text-amber-200 px-2 py-0.5 rounded-full">
+                            {entries.length}
+                        </span>
+                    </div>
+                    <div className="text-[11px] text-amber-700/80 dark:text-amber-300/70 mt-0.5 truncate">
+                        Jede Änderung einzeln zurücksetzbar
+                    </div>
+                </div>
+                <ChevronDown size={16}
+                             className={`text-amber-600 dark:text-amber-400 transition-transform duration-200 shrink-0 ${open ? 'rotate-180' : ''}`}/>
+            </button>
+
+            <AnimatePresence initial={false}>
+                {open && (
+                    <motion.div
+                        initial={{opacity: 0, height: 0}}
+                        animate={{opacity: 1, height: 'auto'}}
+                        exit={{opacity: 0, height: 0}}
+                        transition={{duration: 0.2}}
+                        className="overflow-hidden"
+                    >
+                        <div className="pt-3 flex flex-col gap-3">
+                            {groups.map(g => (
+                                <GroupCard key={g.key} group={g} onRevert={e => revertChange(tab.key, e)}/>
+                            ))}
+                        </div>
+                    </motion.div>
+                )}
+            </AnimatePresence>
+        </div>
+    )
+}
+
+interface Group {
+    key: string
+    group: string
+    itemLabel?: string
+    itemIndex?: number
+    itemKind: 'modified' | 'added' | 'removed'
+    entries: ChangeEntry[]
+}
+
+function groupEntries(entries: ChangeEntry[]): Group[] {
+    const map = new Map<string, Group>()
+    for (const e of entries) {
+        const key = [e.group, e.groupKey ?? '-', e.itemIndex ?? '-', e.kind === 'modified' ? 'm' : e.kind].join('|')
+        let g = map.get(key)
+        if (!g) {
+            g = {
+                key,
+                group: e.group,
+                itemLabel: e.itemLabel,
+                itemIndex: e.itemIndex,
+                itemKind: e.kind === 'modified' ? 'modified' : e.kind,
+                entries: [],
+            }
+            map.set(key, g)
+        }
+        g.entries.push(e)
+    }
+    return [...map.values()]
+}
+
+function GroupCard({group, onRevert}: { group: Group; onRevert: (entry: ChangeEntry) => void }) {
+    const isStructural = group.itemKind !== 'modified'
+    const structural = isStructural ? group.entries[0] : undefined
+
+    return (
+        <div
+            className="bg-white/70 dark:bg-gray-900/40 backdrop-blur-sm border border-gray-200/60 dark:border-gray-700/40 rounded-2xl overflow-hidden">
+            <div className="flex items-center justify-between gap-2 px-4 py-2.5 bg-gray-50/80 dark:bg-gray-800/30 border-b border-gray-200/50 dark:border-gray-700/40">
+                <div className="flex items-center gap-2 min-w-0">
+                    {group.itemKind === 'added' && (
+                        <span className="inline-flex items-center gap-1 text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300">
+                            <Plus size={10}/> Neu
+                        </span>
+                    )}
+                    {group.itemKind === 'removed' && (
+                        <span className="inline-flex items-center gap-1 text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full bg-rose-100 dark:bg-rose-900/30 text-rose-700 dark:text-rose-300">
+                            <Trash2 size={10}/> Entfernt
+                        </span>
+                    )}
+                    <span className="text-[11px] font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400 truncate">
+                        {group.group}
+                    </span>
+                    {group.itemLabel && (
+                        <>
+                            <span className="text-gray-300 dark:text-gray-600">·</span>
+                            <span className="text-xs font-semibold text-gray-700 dark:text-gray-200 truncate">
+                                {group.itemLabel}
+                            </span>
+                        </>
+                    )}
+                </div>
+                {structural && (
+                    <button
+                        type="button"
+                        onClick={() => onRevert(structural)}
+                        className="shrink-0 text-[11px] font-semibold text-amber-700 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-900/20 px-2.5 py-1 rounded-lg border border-amber-300/60 dark:border-amber-700/40 transition-colors flex items-center gap-1.5"
+                        title={group.itemKind === 'added' ? 'Diesen neuen Eintrag verwerfen' : 'Entfernten Eintrag wiederherstellen'}
+                    >
+                        <Undo2 size={11}/>
+                        {group.itemKind === 'added' ? 'Verwerfen' : 'Wiederherstellen'}
+                    </button>
+                )}
+            </div>
+
+            {!isStructural && (
+                <ul className="divide-y divide-gray-100 dark:divide-gray-800">
+                    {group.entries.map(e => (
+                        <li key={e.id}
+                            className="flex items-center justify-between gap-3 px-4 py-3">
+                            <div className="min-w-0 flex-1">
+                                <div className="text-xs font-semibold text-gray-700 dark:text-gray-200 mb-1">
+                                    {e.fieldLabel}
+                                </div>
+                                <div className="flex items-center gap-2 text-[11px] text-gray-500 dark:text-gray-400 min-w-0">
+                                    <span className="line-through text-gray-400 dark:text-gray-500 truncate max-w-[40%]">
+                                        {summarizeValue(e.before, e.fieldType)}
+                                    </span>
+                                    <ArrowRight size={10} className="shrink-0 text-gray-400"/>
+                                    <span className="font-medium text-gray-700 dark:text-gray-300 truncate max-w-[55%]">
+                                        {summarizeValue(e.after, e.fieldType)}
+                                    </span>
+                                </div>
+                            </div>
+                            <button
+                                type="button"
+                                onClick={() => onRevert(e)}
+                                className="shrink-0 text-[11px] font-semibold text-amber-700 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-900/20 px-2.5 py-1 rounded-lg border border-amber-300/60 dark:border-amber-700/40 transition-colors flex items-center gap-1.5"
+                            >
+                                <Undo2 size={11}/> Zurücksetzen
+                            </button>
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    )
+}

--- a/src/admin/components/TabEditor.tsx
+++ b/src/admin/components/TabEditor.tsx
@@ -7,6 +7,7 @@ import FieldRenderer from './FieldRenderer'
 import ArrayEditor from './ArrayEditor'
 import OrphanModal from './OrphanModal'
 import PreviewModal from './PreviewModal'
+import ChangeList from './ChangeList'
 
 interface Props {
     tab: TabConfig
@@ -187,6 +188,9 @@ export default function TabEditor({tab}: Props) {
                 onPublish={handlePublish}
                 onRevert={() => setConfirmRevert(true)}
             />
+
+            {/* Per-change revert panel */}
+            <ChangeList tab={tab}/>
 
             {/* Content */}
             {tab.type === 'array' && tab.fields && (

--- a/src/admin/lib/diff.ts
+++ b/src/admin/lib/diff.ts
@@ -1,0 +1,274 @@
+import type {FieldConfig, TabConfig} from '../types'
+
+export type ChangePath = (string | number)[]
+
+export type ChangeKind = 'modified' | 'added' | 'removed'
+
+export interface ChangeEntry {
+    id: string
+    path: ChangePath
+    kind: ChangeKind
+    group: string
+    groupKey?: string
+    itemIndex?: number
+    itemLabel?: string
+    fieldKey?: string
+    fieldLabel?: string
+    fieldType?: FieldConfig['type']
+    before?: unknown
+    after?: unknown
+    // For removed items, the original array index we'd re-insert at
+    originalIndex?: number
+}
+
+const eq = (a: unknown, b: unknown): boolean => {
+    if (a === b) return true
+    if (a == null || b == null) return a === b
+    if (typeof a !== typeof b) return false
+    if (typeof a === 'object') return JSON.stringify(a) === JSON.stringify(b)
+    return false
+}
+
+function itemLabel(fields: FieldConfig[], item: Record<string, unknown> | undefined, fallbackIndex: number): string {
+    if (!item) return `#${fallbackIndex + 1}`
+    const byKey = (k: string) => typeof item[k] === 'string' && (item[k] as string).trim()
+        ? (item[k] as string).trim() : undefined
+    const preferred = byKey('name') || byKey('titel') || byKey('jahr')
+    if (preferred) return preferred
+    // fall back to the first text-like field that has a value
+    for (const f of fields) {
+        if (f.type === 'text' || f.type === 'email' || f.type === 'url') {
+            const v = byKey(f.key)
+            if (v) return v
+        }
+    }
+    return `#${fallbackIndex + 1}`
+}
+
+function diffFields(
+    fields: FieldConfig[],
+    original: Record<string, unknown> | undefined,
+    current: Record<string, unknown> | undefined,
+    basePath: ChangePath,
+    group: string,
+    groupKey: string | undefined,
+    itemIdx: number | undefined,
+    itemLbl: string | undefined,
+    out: ChangeEntry[],
+) {
+    const orig = original ?? {}
+    const curr = current ?? {}
+    for (const f of fields) {
+        const before = orig[f.key]
+        const after = curr[f.key]
+        if (eq(before, after)) continue
+        const fieldPath: ChangePath = [...basePath, f.key]
+        out.push({
+            id: fieldPath.join('.') + ':modified',
+            path: fieldPath,
+            kind: 'modified',
+            group,
+            groupKey,
+            itemIndex: itemIdx,
+            itemLabel: itemLbl,
+            fieldKey: f.key,
+            fieldLabel: f.label,
+            fieldType: f.type,
+            before, after,
+        })
+    }
+}
+
+function diffArray(
+    fields: FieldConfig[],
+    original: Record<string, unknown>[] | undefined,
+    current: Record<string, unknown>[] | undefined,
+    basePath: ChangePath,
+    group: string,
+    groupKey: string | undefined,
+    out: ChangeEntry[],
+) {
+    const orig = Array.isArray(original) ? original : []
+    const curr = Array.isArray(current) ? current : []
+    const common = Math.min(orig.length, curr.length)
+    for (let i = 0; i < common; i++) {
+        const o = orig[i] as Record<string, unknown> | undefined
+        const c = curr[i] as Record<string, unknown> | undefined
+        if (eq(o, c)) continue
+        diffFields(fields, o, c, [...basePath, i], group, groupKey, i, itemLabel(fields, c, i), out)
+    }
+    // added
+    for (let i = common; i < curr.length; i++) {
+        const c = curr[i] as Record<string, unknown> | undefined
+        const path: ChangePath = [...basePath, i]
+        out.push({
+            id: path.join('.') + ':added',
+            path,
+            kind: 'added',
+            group,
+            groupKey,
+            itemIndex: i,
+            itemLabel: itemLabel(fields, c, i),
+            after: c,
+        })
+    }
+    // removed
+    for (let i = common; i < orig.length; i++) {
+        const o = orig[i] as Record<string, unknown> | undefined
+        const path: ChangePath = [...basePath, i]
+        out.push({
+            id: path.join('.') + ':removed:' + i,
+            path,
+            kind: 'removed',
+            group,
+            groupKey,
+            itemIndex: i,
+            originalIndex: i,
+            itemLabel: itemLabel(fields, o, i),
+            before: o,
+        })
+    }
+}
+
+export function diffTab(
+    tab: TabConfig,
+    original: unknown,
+    current: unknown,
+): ChangeEntry[] {
+    const out: ChangeEntry[] = []
+    if (tab.type === 'haushaltsreden') return out
+
+    if (tab.type === 'array' && tab.fields) {
+        diffArray(
+            tab.fields,
+            original as Record<string, unknown>[] | undefined,
+            current as Record<string, unknown>[] | undefined,
+            [],
+            tab.label,
+            undefined,
+            out,
+        )
+        return out
+    }
+
+    const orig = (original ?? {}) as Record<string, unknown>
+    const curr = (current ?? {}) as Record<string, unknown>
+
+    if (tab.topFields) {
+        diffFields(tab.topFields, orig, curr, [], 'Allgemein', undefined, undefined, undefined, out)
+    }
+    if (tab.sections) {
+        for (const sec of tab.sections) {
+            if (sec.isSingleObject) {
+                diffFields(
+                    sec.fields,
+                    orig[sec.key] as Record<string, unknown> | undefined,
+                    curr[sec.key] as Record<string, unknown> | undefined,
+                    [sec.key],
+                    sec.label,
+                    sec.key,
+                    undefined,
+                    undefined,
+                    out,
+                )
+            } else {
+                diffArray(
+                    sec.fields,
+                    orig[sec.key] as Record<string, unknown>[] | undefined,
+                    curr[sec.key] as Record<string, unknown>[] | undefined,
+                    [sec.key],
+                    sec.label,
+                    sec.key,
+                    out,
+                )
+            }
+        }
+    }
+    return out
+}
+
+// Apply a single revert: given the current value at tab root, produce a new
+// value where the change at `entry` has been rolled back to `originalRoot`.
+export function applyRevert(
+    _tab: TabConfig,
+    originalRoot: unknown,
+    currentRoot: unknown,
+    entry: ChangeEntry,
+): unknown {
+    const next = clone(currentRoot)
+    if (entry.kind === 'modified') {
+        const beforeValue = getAtPath(originalRoot, entry.path)
+        setAtPath(next, entry.path, clone(beforeValue))
+        return next
+    }
+    if (entry.kind === 'added') {
+        // remove the element at the array path
+        const parentPath = entry.path.slice(0, -1)
+        const idx = entry.path[entry.path.length - 1] as number
+        const arr = getAtPath(next, parentPath) as unknown
+        if (Array.isArray(arr)) arr.splice(idx, 1)
+        return next
+    }
+    if (entry.kind === 'removed') {
+        // reinsert at the original index (clamped)
+        const parentPath = entry.path.slice(0, -1)
+        const idx = entry.originalIndex ?? (entry.path[entry.path.length - 1] as number)
+        let arr = getAtPath(next, parentPath) as unknown
+        if (!Array.isArray(arr)) {
+            // initialize empty array at that path
+            arr = []
+            setAtPath(next, parentPath, arr)
+        }
+        (arr as unknown[]).splice(Math.min(idx, (arr as unknown[]).length), 0, clone(entry.before))
+        return next
+    }
+    return next
+}
+
+function clone<T>(v: T): T {
+    return v === undefined ? v : (JSON.parse(JSON.stringify(v)) as T)
+}
+
+function getAtPath(root: unknown, path: ChangePath): unknown {
+    let cur: unknown = root
+    for (const seg of path) {
+        if (cur == null) return undefined
+        cur = (cur as Record<string | number, unknown>)[seg as never]
+    }
+    return cur
+}
+
+function setAtPath(root: unknown, path: ChangePath, value: unknown): void {
+    if (path.length === 0) return
+    let cur: unknown = root
+    for (let i = 0; i < path.length - 1; i++) {
+        const seg = path[i]
+        const next = (cur as Record<string | number, unknown>)[seg as never]
+        if (next == null) {
+            const followSeg = path[i + 1]
+            const created: unknown = typeof followSeg === 'number' ? [] : {}
+            ;(cur as Record<string | number, unknown>)[seg as never] = created as never
+            cur = created
+        } else {
+            cur = next
+        }
+    }
+    const last = path[path.length - 1]
+    ;(cur as Record<string | number, unknown>)[last as never] = value as never
+}
+
+export function summarizeValue(v: unknown, type?: FieldConfig['type']): string {
+    if (v == null || v === '') return '—'
+    if (type === 'image' && typeof v === 'string') return v.split('/').pop() || String(v)
+    if (type === 'imagelist' && Array.isArray(v)) return `${v.length} Bild(er)`
+    if (type === 'stringlist' && Array.isArray(v)) return v.length ? v.join(', ') : '—'
+    if (type === 'textarea' && typeof v === 'string') {
+        const t = v.trim().replace(/\s+/g, ' ')
+        return t.length > 80 ? t.slice(0, 80) + '…' : t
+    }
+    if (typeof v === 'string') return v.length > 80 ? v.slice(0, 80) + '…' : v
+    if (typeof v === 'number' || typeof v === 'boolean') return String(v)
+    if (Array.isArray(v)) return `[${v.length}]`
+    if (typeof v === 'object') return '{…}'
+    return String(v)
+}

--- a/src/admin/store.ts
+++ b/src/admin/store.ts
@@ -2,6 +2,7 @@ import {create} from 'zustand'
 import type {GHUser, PendingUpload, TabConfig} from './types'
 import {TABS} from './config/tabs'
 import {collectImagePaths} from './lib/images'
+import {applyRevert, type ChangeEntry} from './lib/diff'
 import {commitTree, validateToken, type TreeFileChange} from './lib/github'
 
 const TOKEN_KEY = 'spd-admin-token'
@@ -103,6 +104,7 @@ interface AdminState {
     publishAll: (orphansToDelete?: string[]) => Promise<void>
     resetOriginal: (tabKey: string) => void
     revertTab: (tabKey: string) => void
+    revertChange: (tabKey: string, entry: ChangeEntry) => void
     toggleDark: () => void
     setStatus: (msg: string, type: 'info' | 'success' | 'error') => void
     findOrphanImages: () => string[]
@@ -365,6 +367,31 @@ export const useAdminStore = create<AdminState>((set, get) => ({
                 undoStacks: {...prev.undoStacks, [tabKey]: []},
                 redoStacks: {...prev.redoStacks, [tabKey]: []},
                 statusMessage: 'Änderungen verworfen.',
+                statusType: 'info' as const,
+                statusCounter: prev.statusCounter + 1,
+            }
+        })
+    },
+
+    revertChange: (tabKey, entry) => {
+        set(prev => {
+            const tab = TABS.find(t => t.key === tabKey)
+            if (!tab) return prev
+            const nextTabValue = applyRevert(tab as TabConfig, prev.originalState[tabKey], prev.state[tabKey], entry)
+            const nextState = {...prev.state, [tabKey]: nextTabValue}
+            // Drop pending uploads whose target path is no longer referenced by any tab
+            const allPaths = new Set<string>()
+            for (const t of TABS) {
+                if (!t.file || !nextState[t.key]) continue
+                for (const p of collectImagePaths(t as TabConfig, nextState[t.key] as Record<string, unknown>)) {
+                    allPaths.add(p)
+                }
+            }
+            const keptUploads = prev.pendingUploads.filter(u => allPaths.has(u.ghPath.replace(/^public/, '')))
+            return {
+                state: nextState,
+                pendingUploads: keptUploads,
+                statusMessage: 'Änderung zurückgesetzt.',
                 statusType: 'info' as const,
                 statusCounter: prev.statusCounter + 1,
             }


### PR DESCRIPTION
## Summary
- Fix admin review bugs: tab-scoped `publishTab` upload matching, caption-add race, `collectImagePaths` now scans `topFields` / single-object sections, `HaushaltsredenEditor.toggleYear` awaits save and reverts on failure, Tailwind v4 arbitrary z-index, beforeunload `returnValue`.
- Mobile UX: always-visible drag grip on sortable cards; rebuilt `CropOverlay` with pointer events, pinch / wheel zoom, per-corner handles, rule-of-thirds guides and responsive toolbar; redesigned image / imagelist fields with preview + action row and collapsible URL input; Facebook/Instagram/Calendar/Link/Mail/Phone icon prefixes on contact + URL fields; sticky "Veröffentlichen" bar when scrolled with unsaved changes; full-tab revert button + modal.
- New **per-change revert** feature: `diffTab` / `applyRevert` utilities, `revertChange` store action, and a collapsible "Ungespeicherte Änderungen" panel that lists every local change with `old → new` previews and an individual revert button (added/removed items collapse to a single "Verwerfen" / "Wiederherstellen").

## Test plan
- [ ] Edit a news item, confirm the change appears in the panel and single-row revert restores only that field.
- [ ] Add a new entry in a section, verify "Neu" row with "Verwerfen" removes it.
- [ ] Delete an existing entry, verify "Entfernt" row with "Wiederherstellen" puts it back at the original index.
- [ ] Publish a single dirty tab, confirm only that tab's pending uploads are flushed.
- [ ] On mobile / touch, pan + pinch-zoom the crop overlay, drag corner handles, export crop.
- [ ] Scroll a long tab with unsaved changes, confirm sticky publish bar appears with revert action.

https://claude.ai/code/session_01LBXmWGdJKQnNwPscqh5Pwa