### PR TITLE
Lazy-load Instagram widget and add dark mode support

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,8 +66,7 @@
     }
     </script>
 
-    <!-- Elfsight Instagram Feed -->
-    <script src="https://elfsightcdn.com/platform.js" async></script>
+    <!-- Elfsight branding removal (script itself is loaded lazily on /aktuelles) -->
     <script>
       (function () {
         function removeElfsightUI() {

--- a/src/components/sections/Aktuelles.tsx
+++ b/src/components/sections/Aktuelles.tsx
@@ -412,6 +412,31 @@ export default function Aktuelles() {
   const config = useConfig()
   const elfsightAppId = config?.elfsightAppId
 
+  // Track dark mode by observing the class on <html>
+  const [isDark, setIsDark] = useState(() =>
+    document.documentElement.classList.contains('dark')
+  )
+  useEffect(() => {
+    const obs = new MutationObserver(() => {
+      setIsDark(document.documentElement.classList.contains('dark'))
+    })
+    obs.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
+    return () => obs.disconnect()
+  }, [])
+
+  // Lazy-load the Elfsight platform script only when on this page
+  useEffect(() => {
+    if (!elfsightAppId) return
+    const SCRIPT_ID = 'elfsight-platform'
+    if (!document.getElementById(SCRIPT_ID)) {
+      const script = document.createElement('script')
+      script.id = SCRIPT_ID
+      script.src = 'https://elfsightcdn.com/platform.js'
+      script.async = true
+      document.head.appendChild(script)
+    }
+  }, [elfsightAppId])
+
   useHttpErrorRedirect(newsError)
 
   const allTags = newsItems
@@ -696,7 +721,12 @@ export default function Aktuelles() {
             </a>
           </div>
           {elfsightAppId && (
-            <div className={`elfsight-app-${elfsightAppId}`} data-elfsight-app-lazy />
+            <div
+              key={isDark ? 'dark' : 'light'}
+              className={`elfsight-app-${elfsightAppId}`}
+              data-elfsight-app-lazy
+              data-elfsight-app-theme={isDark ? 'dark' : 'light'}
+            />
           )}
         </motion.div>
       </div>


### PR DESCRIPTION
## Summary

- Remove Elfsight `platform.js` from `index.html` so it no longer loads on every page load
- Dynamically inject the script inside `Aktuelles` only when the component mounts and `elfsightAppId` is configured
- Observe `<html>` class mutations in `Aktuelles` to track the app's dark/light mode toggle
- Pass `data-elfsight-app-theme` to the widget div and key it on `isDark` so the widget re-initialises with the correct theme whenever the user toggles dark mode

## Test plan

- [ ] Visit any page other than `/aktuelles` and confirm `platform.js` is not loaded in the network tab
- [ ] Navigate to `/aktuelles` and confirm `platform.js` loads and the Instagram feed renders
- [ ] Toggle dark mode and confirm the Instagram widget re-renders in the correct theme
- [ ] Navigate away from `/aktuelles` and back — confirm the widget loads correctly on return

---
_Generated by [Claude Code](https://claude.ai/code/session_018c7Pg49JTmykDgUuS6K5Ga)_