### PR TITLE
Refine Instagram popup dark mode: username red, separator dark, carousel bar transparent

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -101,12 +101,21 @@ html.dark body {
   border-top-color: #334155 !important;
   color: #e2e8f0 !important;
 }
+/* Username in SPD red */
 .dark [class*="eapps-instagram-feed-popup"] [class*="username"],
+.dark [class*="eapps-instagram-feed-popup"] [class*="user-name"],
+.dark [class*="eapps-instagram-feed-popup"] [class*="handle"] {
+  color: #E3000F !important;
+}
 .dark [class*="eapps-instagram-feed-popup"] [class*="caption"],
 .dark [class*="eapps-instagram-feed-popup"] [class*="likes"],
 .dark [class*="eapps-instagram-feed-popup"] [class*="date"],
 .dark [class*="eapps-instagram-feed-popup"] [class*="comments"],
-.dark [class*="eapps-instagram-feed-popup"] [class*="fullname"] {
+.dark [class*="eapps-instagram-feed-popup"] [class*="fullname"],
+.dark [class*="eapps-instagram-feed-popup"] [class*="count"],
+.dark [class*="eapps-instagram-feed-popup"] [class*="text"],
+.dark [class*="eapps-instagram-feed-popup"] p,
+.dark [class*="eapps-instagram-feed-popup"] span:not([class*="follow"]):not([class*="btn"]) {
   color: #e2e8f0 !important;
 }
 .dark [class*="eapps-instagram-feed-popup-arrow"] {
@@ -116,5 +125,23 @@ html.dark body {
 .dark [class*="eapps-instagram-feed-popup-close"] {
   background-color: rgba(30, 41, 59, 0.85) !important;
   color: #e2e8f0 !important;
+}
+/* White separator line between sections → dark */
+.dark [class*="eapps-instagram-feed-popup"] hr,
+.dark [class*="eapps-instagram-feed-popup"] [class*="divider"],
+.dark [class*="eapps-instagram-feed-popup"] [class*="separator"],
+.dark [class*="eapps-instagram-feed-popup"] [class*="line"]:not([class*="slider"]) {
+  border-color: #334155 !important;
+  background-color: #334155 !important;
+}
+/* Carousel: hide the blue progress bar, keep only the dots */
+.dark [class*="eapps-instagram-feed-popup"] [class*="slider-line"],
+.dark [class*="eapps-instagram-feed-popup"] [class*="progress-line"],
+.dark [class*="eapps-instagram-feed-popup"] [class*="slider-track"],
+.dark [class*="eapps-instagram-feed-popup"] [class*="progress-track"],
+.dark [class*="eapps-instagram-feed-popup"] [class*="progress-bar"],
+.dark [class*="eapps-instagram-feed-popup"] [class*="track"]:not([class*="dot"]) {
+  background-color: transparent !important;
+  border-color: transparent !important;
 }
 


### PR DESCRIPTION
## Changes

- **Username** – `spdalbstadt` now renders in SPD red (`#E3000F`) in dark mode
- **White separator line** – horizontal divider between the image and the likes/caption area is overridden to dark (`#334155`) in dark mode
- **Carousel progress bar** – the blue line running through the dot indicators is made `transparent` so only the dots themselves remain visible in dark mode
- Extended text-colour overrides to catch `p`, `span`, `count`, and `text` class variants for better coverage of body text

---
_Generated by [Claude Code](https://claude.ai/code/session_018c7Pg49JTmykDgUuS6K5Ga)_