### PR TITLE
Prevent widget reload on theme switch; fix arrow/close dark mode

### DIFF
--- a/src/components/sections/Aktuelles.tsx
+++ b/src/components/sections/Aktuelles.tsx
@@ -412,18 +412,6 @@ export default function Aktuelles() {
   const config = useConfig()
   const elfsightAppId = config?.elfsightAppId
 
-  // Track dark mode by observing the class on <html>
-  const [isDark, setIsDark] = useState(() =>
-    document.documentElement.classList.contains('dark')
-  )
-  useEffect(() => {
-    const obs = new MutationObserver(() => {
-      setIsDark(document.documentElement.classList.contains('dark'))
-    })
-    obs.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] })
-    return () => obs.disconnect()
-  }, [])
-
   // Lazy-load the Elfsight platform script only when on this page
   useEffect(() => {
     if (!elfsightAppId) return
@@ -722,10 +710,9 @@ export default function Aktuelles() {
           </div>
           {elfsightAppId && (
             <div
-              key={isDark ? 'dark' : 'light'}
               className={`elfsight-app-${elfsightAppId}`}
               data-elfsight-app-lazy
-              data-elfsight-app-theme={isDark ? 'dark' : 'light'}
+              data-elfsight-app-theme={document.documentElement.classList.contains('dark') ? 'dark' : 'light'}
             />
           )}
         </motion.div>

--- a/src/index.css
+++ b/src/index.css
@@ -123,14 +123,49 @@ html.dark body {
 .dark [class*="eapps-instagram-feed-popup"] span:not([class*="follow"]):not([class*="btn"]) {
   color: #e2e8f0 !important;
 }
-/* Nav arrows / close button */
-.dark [class*="eapps-instagram-feed-popup-arrow"] {
-  background-color: rgba(30, 41, 59, 0.85) !important;
-  color: #e2e8f0 !important;
+/* Nav arrows / close button — broad selectors + SVG fill override */
+.dark [class*="eapps-instagram-feed-popup"] [class*="arrow"],
+.dark [class*="eapps-instagram-feed-popup"] [class*="prev"],
+.dark [class*="eapps-instagram-feed-popup"] [class*="next"],
+.dark [class*="eapps-instagram-feed-popup"] [class*="close"],
+.dark [class*="eapps-instagram-feed-popup"] [class*="dismiss"],
+.dark [class*="eapps-instagram-feed-popup"] [class*="button"],
+.dark [class*="eapps-instagram-feed-popup"] [class*="-btn"] {
+  background-color: rgba(15, 23, 42, 0.75) !important;
+  color: #ffffff !important;
+  border-color: #334155 !important;
 }
-.dark [class*="eapps-instagram-feed-popup-close"] {
-  background-color: rgba(30, 41, 59, 0.85) !important;
-  color: #e2e8f0 !important;
+.dark [class*="eapps-instagram-feed-popup"] [class*="arrow"] svg,
+.dark [class*="eapps-instagram-feed-popup"] [class*="prev"] svg,
+.dark [class*="eapps-instagram-feed-popup"] [class*="next"] svg,
+.dark [class*="eapps-instagram-feed-popup"] [class*="close"] svg,
+.dark [class*="eapps-instagram-feed-popup"] [class*="arrow"] path,
+.dark [class*="eapps-instagram-feed-popup"] [class*="prev"] path,
+.dark [class*="eapps-instagram-feed-popup"] [class*="next"] path,
+.dark [class*="eapps-instagram-feed-popup"] [class*="close"] path,
+.dark [class*="eapps-instagram-feed-popup"] [class*="arrow"] polyline,
+.dark [class*="eapps-instagram-feed-popup"] [class*="close"] polyline {
+  fill: #ffffff !important;
+  stroke: #ffffff !important;
+}
+/* Light mode: restore clean light styling for arrows/close */
+[class*="eapps-instagram-feed-popup"] [class*="arrow"],
+[class*="eapps-instagram-feed-popup"] [class*="prev"],
+[class*="eapps-instagram-feed-popup"] [class*="next"],
+[class*="eapps-instagram-feed-popup"] [class*="close"] {
+  background-color: rgba(255, 255, 255, 0.9) !important;
+  color: #111827 !important;
+}
+[class*="eapps-instagram-feed-popup"] [class*="arrow"] svg,
+[class*="eapps-instagram-feed-popup"] [class*="prev"] svg,
+[class*="eapps-instagram-feed-popup"] [class*="next"] svg,
+[class*="eapps-instagram-feed-popup"] [class*="close"] svg,
+[class*="eapps-instagram-feed-popup"] [class*="arrow"] path,
+[class*="eapps-instagram-feed-popup"] [class*="close"] path,
+[class*="eapps-instagram-feed-popup"] [class*="arrow"] polyline,
+[class*="eapps-instagram-feed-popup"] [class*="close"] polyline {
+  fill: #111827 !important;
+  stroke: #111827 !important;
 }
 /* Carousel progress bar/track → transparent, dots remain visible.
    Cast a wide net across every possible Elfsight class name variant. */


### PR DESCRIPTION
## Changes

**No more reload on theme switch (`Aktuelles.tsx`)**
- Removed the `isDark` state + MutationObserver — CSS handles live theme changes without any JS
- Removed the `key` prop from the widget div so Elfsight never re-initialises when the toggle is flipped
- `data-elfsight-app-theme` is still set correctly at initial render via a direct DOM read

**Arrow & close button dark mode (`index.css`)**
- Replaced narrow `-arrow` / `-close` selectors with broad `class*=` variants covering `arrow`, `prev`, `next`, `close`, `dismiss`, `button`, `btn`
- Added SVG / `path` / `polyline` fill + stroke overrides so icon-based controls turn white in dark mode
- Added explicit light-mode counterpart rules (white bg, dark icons) so the controls correctly adapt in both directions

---
_Generated by [Claude Code](https://claude.ai/code/session_018c7Pg49JTmykDgUuS6K5Ga)_