### PR TITLE
fix: document upload in kommunalpolitik not detected as a change

### DIFF
--- a/src/admin/store.ts
+++ b/src/admin/store.ts
@@ -167,6 +167,12 @@ export const useAdminStore = create<AdminState>((set, get) => ({
                 dirty.add(tab.key)
             }
         }
+        // Mark a tab dirty if it owns a pending upload — the tabKey is the ground truth,
+        // so this catches document uploads where the new URL may not yet be in the state
+        // (race between addPendingUpload and the state update from onChange).
+        for (const upload of pendingUploads) {
+            if (upload.tabKey) dirty.add(upload.tabKey)
+        }
         // Also mark a tab dirty if there's a pending image upload targeting a path
         // referenced by the tab — otherwise replacing an image with the same URL
         // (e.g. same-named Abgeordneter) would leave the tab undetected as changed.


### PR DESCRIPTION
## Summary

- `dirtyTabs()` now marks a tab dirty as soon as it owns a pending upload (via `upload.tabKey`), not only when the new URL is already reflected in the state
- Fixes the race where `addPendingUpload` fires before `onChange` updates `state['kommunalpolitik']`, leaving the publish button disabled after a document upload

## Root cause

When uploading a document, `addPendingUpload` runs first and `onChange` (which writes the new URL into the state) runs right after. If the Zustand selector re-evaluated between those two calls, the path-matching check found no match (new URL not yet in state) and the JSON comparison showed no change — so `isDirty` stayed `false` and the publish button stayed disabled.

## Fix

Added a direct `tabKey` check before the existing path-based fallback in `dirtyTabs()`. Any pending upload stamped with a tab's key immediately marks that tab dirty. `revertTab` already drops uploads by `tabKey`, so reverting correctly clears the flag.

https://claude.ai/code/session_01B3t5XC9AdvaFjk5poRsooQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3t5XC9AdvaFjk5poRsooQ)_