### PR TITLE
Remove profession from Gemeinderat/Kreisrat preview cards

### DIFF
--- a/src/components/sections/Fraktion/PersonGrid.tsx
+++ b/src/components/sections/Fraktion/PersonGrid.tsx
@@ -51,7 +51,6 @@ export function PersonGrid({
             key={m.name}
             name={m.name}
             bildUrl={m.bildUrl}
-            label={m.beruf}
             sublabel={`seit ${m.seit}`}
             onClick={() => onSelect(m)}
           />

--- a/src/components/sections/Partei/index.tsx
+++ b/src/components/sections/Partei/index.tsx
@@ -127,7 +127,6 @@ export default function Partei() {
                   key={m.name}
                   name={m.name}
                   bildUrl={m.bildUrl}
-                  label={m.rolle}
                   priority={i === 0}
                   onClick={() => dispatch({ type: 'openPerson', person: m })}
                 />

--- a/src/components/sections/Partei/index.tsx
+++ b/src/components/sections/Partei/index.tsx
@@ -127,6 +127,7 @@ export default function Partei() {
                   key={m.name}
                   name={m.name}
                   bildUrl={m.bildUrl}
+                  label={m.rolle}
                   priority={i === 0}
                   onClick={() => dispatch({ type: 'openPerson', person: m })}
                 />


### PR DESCRIPTION
Beruf wird nicht mehr auf den Vorschau-Kärtchen der Gemeinderäte und Kreisräte angezeigt. In der Detail-Ansicht (PersonSheet) bleibt der Beruf weiterhin sichtbar.