### PR TITLE
fix: replace deprecated deny-licenses with allow-licenses

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,4 +22,4 @@ jobs:
         with:
           fail-on-severity: high
           comment-summary-in-pr: always
-          deny-licenses: GPL-3.0, AGPL-3.0
+          allow-licenses: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, 0BSD, CC0-1.0, CC-BY-3.0, CC-BY-4.0, Unlicense, BlueOak-1.0.0, Python-2.0


### PR DESCRIPTION
Behebt den Deprecation-Warning in der Dependency Review Action.

`deny-licenses` ist deprecated (actions/dependency-review-action#997) und wird in der nächsten Major-Version entfernt.

**Änderung:** `deny-licenses: GPL-3.0, AGPL-3.0` → `allow-licenses: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, 0BSD, CC0-1.0, CC-BY-3.0, CC-BY-4.0, Unlicense, BlueOak-1.0.0, Python-2.0`

Statt zu verbieten, was nicht erlaubt ist, wird jetzt explizit aufgelistet, welche Lizenzen erlaubt sind. GPL-3.0 und AGPL-3.0 sind damit weiterhin blockiert.