### PR TITLE
Vereinheitliche Hintergrundfarben: Aktuelles & Fraktion auf bg-gray-50/dark:bg-gray-900

### DIFF
--- a/src/components/sections/Aktuelles/index.tsx
+++ b/src/components/sections/Aktuelles/index.tsx
@@ -94,7 +94,7 @@ export default function Aktuelles() {
   }
 
   return (
-    <section id="aktuelles" className="py-24 bg-white dark:bg-gray-950">
+    <section id="aktuelles" className="py-24 bg-gray-50 dark:bg-gray-900">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <SectionHeader
           sectionRef={ref}

--- a/src/components/sections/Fraktion/index.tsx
+++ b/src/components/sections/Fraktion/index.tsx
@@ -51,7 +51,7 @@ export default function Fraktion() {
   } = useHaushaltsredenPagination()
 
   return (
-    <section id="fraktion" className="py-24 bg-white dark:bg-gray-950">
+    <section id="fraktion" className="py-24 bg-gray-50 dark:bg-gray-900">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <SectionHeader
           sectionRef={ref}


### PR DESCRIPTION
Passt Aktuelles und Fraktion an Partei an, sodass alle drei Sektionen dieselbe Hintergrundfarbe teilen (`bg-gray-50` Light / `dark:bg-gray-900` Dark).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QzviLq3AT9H4R4DCxQ3pZ8)_