### PR TITLE
Add share button to news detail sheet

### DIFF
--- a/src/components/sections/Aktuelles/NewsDetailSheet.tsx
+++ b/src/components/sections/Aktuelles/NewsDetailSheet.tsx
@@ -20,7 +20,7 @@ export default function NewsDetailSheet({ news }: Props) {
       : `${BASE_URL}${urls[0]}`
     : undefined
   const deepId = news.uuid ?? news.id
-  const shareUrl = `${BASE_URL}/aktuelles/${deepId}`
+  const shareUrl = `${window.location.origin}/aktuelles/${deepId}`
 
   const [copied, setCopied] = useState(false)
 

--- a/src/components/sections/Aktuelles/NewsDetailSheet.tsx
+++ b/src/components/sections/Aktuelles/NewsDetailSheet.tsx
@@ -62,13 +62,21 @@ export default function NewsDetailSheet({ news }: Props) {
       </Helmet>
       {urls.length > 0 && <PhotoGallery images={urls} captions={captions} alt={news.titel} />}
       <div className="p-6 sm:p-8">
-        <div className="flex items-center gap-3 mb-3 flex-wrap">
+        <div className="flex items-center gap-3 mb-3">
           <span
             className={`text-xs font-semibold px-2.5 py-1 rounded-full ${CATEGORY_COLORS[news.kategorie]}`}
           >
             {news.kategorie}
           </span>
-          <time className="text-sm text-gray-400">{formatDate(news.datum)}</time>
+          <time className="text-sm text-gray-400 flex-1">{formatDate(news.datum)}</time>
+          <button
+            type="button"
+            onClick={handleShare}
+            aria-label="Beitrag teilen"
+            className="w-8 h-8 rounded-lg bg-spd-red/10 hover:bg-spd-red flex items-center justify-center text-spd-red hover:text-white transition-all duration-200 active:scale-[0.95] shrink-0"
+          >
+            {copied ? <Check size={15} /> : <Share2 size={15} />}
+          </button>
         </div>
         <h3 className="text-xl sm:text-2xl font-black text-gray-900 dark:text-white leading-tight mb-4">
           {news.titel}
@@ -77,16 +85,6 @@ export default function NewsDetailSheet({ news }: Props) {
         <p className="text-gray-700 dark:text-gray-300 leading-relaxed text-base whitespace-pre-line">
           {news.inhalt}
         </p>
-        <div className="mt-8 pt-6 border-t border-gray-100 dark:border-gray-800">
-          <button
-            type="button"
-            onClick={handleShare}
-            className="w-full flex items-center justify-center gap-2 bg-spd-red/10 hover:bg-spd-red text-spd-red hover:text-white text-sm font-bold py-3 px-5 rounded-xl transition-all duration-200 active:scale-[0.98]"
-          >
-            {copied ? <Check size={16} /> : <Share2 size={16} />}
-            {copied ? 'Link kopiert!' : 'Beitrag teilen'}
-          </button>
-        </div>
       </div>
     </div>
   )

--- a/src/components/sections/Aktuelles/NewsDetailSheet.tsx
+++ b/src/components/sections/Aktuelles/NewsDetailSheet.tsx
@@ -1,4 +1,6 @@
+import { useState } from 'react'
 import { Helmet } from 'react-helmet-async'
+import { Check, Share2 } from 'lucide-react'
 import type { NewsItem } from '@/types/news'
 import { CATEGORY_COLORS, getNewsImages } from '@/types/news'
 import { formatDate } from '@/utils/formatDate'
@@ -18,6 +20,27 @@ export default function NewsDetailSheet({ news }: Props) {
       : `${BASE_URL}${urls[0]}`
     : undefined
   const deepId = news.uuid ?? news.id
+  const shareUrl = `${BASE_URL}/aktuelles/${deepId}`
+
+  const [copied, setCopied] = useState(false)
+
+  async function handleShare() {
+    if (navigator.share) {
+      try {
+        await navigator.share({
+          title: `${news.titel} – SPD Albstadt`,
+          text: news.zusammenfassung,
+          url: shareUrl,
+        })
+      } catch {
+        // user cancelled or error — no action needed
+      }
+    } else {
+      await navigator.clipboard.writeText(shareUrl)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    }
+  }
 
   return (
     <div>
@@ -54,6 +77,16 @@ export default function NewsDetailSheet({ news }: Props) {
         <p className="text-gray-700 dark:text-gray-300 leading-relaxed text-base whitespace-pre-line">
           {news.inhalt}
         </p>
+        <div className="mt-8 pt-6 border-t border-gray-100 dark:border-gray-800">
+          <button
+            type="button"
+            onClick={handleShare}
+            className="w-full flex items-center justify-center gap-2 bg-spd-red/10 hover:bg-spd-red text-spd-red hover:text-white text-sm font-bold py-3 px-5 rounded-xl transition-all duration-200 active:scale-[0.98]"
+          >
+            {copied ? <Check size={16} /> : <Share2 size={16} />}
+            {copied ? 'Link kopiert!' : 'Beitrag teilen'}
+          </button>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
Adds a share button to each news article in the Aktuelles section.

- Icon-only button in the top metadata row (next to category badge and date), always visible without scrolling
- Uses the Web Share API on mobile/supported browsers; falls back to copying the link to clipboard with a brief "Link kopiert!" confirmation
- Share URL uses `window.location.origin` so it works correctly on Vercel previews and localhost, not just production

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFYvCGhi5ecA78zygDFhgP)_