### PR TITLE
Wire Haushaltsreden toggle through the normal publish flow

### DIFF
--- a/src/admin/config/tabs.ts
+++ b/src/admin/config/tabs.ts
@@ -154,8 +154,8 @@ export const TABS: TabConfig[] = [
     key: 'haushaltsreden',
     label: 'Haushaltsreden',
     type: 'haushaltsreden',
-    file: null,
-    ghPath: null,
+    file: '/data/haushaltsreden.json',
+    ghPath: 'public/data/haushaltsreden.json',
   },
   {
     key: 'history',

--- a/src/admin/hooks/useHaushaltsredenEditor.ts
+++ b/src/admin/hooks/useHaushaltsredenEditor.ts
@@ -1,14 +1,16 @@
 /**
  * All state and async logic for the Haushaltsreden editor, extracted from
  * HaushaltsredenEditor.tsx so the component file is a thin render-only layer.
+ *
+ * Visibility toggles now go through the normal store → dirty-tracking →
+ * Veröffentlichen flow, exactly like every other tab. PDF uploads/deletes
+ * remain immediate operations (binary files committed directly).
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useAdminStore } from '../store'
 import {
   commitBinaryFile,
-  commitFile,
   deleteFile,
-  getFileContent,
   listDirectory,
 } from '../lib/github'
 import { fileToBase64 } from '../lib/images'
@@ -35,18 +37,17 @@ export interface HaushaltsredenEditorState {
 export function useHaushaltsredenEditor(): HaushaltsredenEditorState {
   const ensureAuthenticated = useAdminStore(s => s.ensureAuthenticated)
   const setStatus = useAdminStore(s => s.setStatus)
+  const storeData = useAdminStore(
+    s => s.state['haushaltsreden'] as { disabledYears?: number[] } | null,
+  )
+  const updateState = useAdminStore(s => s.updateState)
 
   const [existingMap, setExistingMap] = useState<Record<number, string>>({})
-  const [disabledYears, setDisabledYears] = useState<Set<number>>(new Set())
   const [loading, setLoading] = useState(true)
   const [loadError, setLoadError] = useState(false)
   const [busy, setBusy] = useState<number | null>(null)
   const [confirmDeleteYear, setConfirmDeleteYear] = useState<number | null>(null)
 
-  // Ref so toggleYear's queued closures always read the latest disabled set.
-  const toggleQueue = useRef(Promise.resolve())
-  const latestDisabled = useRef(disabledYears)
-  // Guard so queued async callbacks won't call setState after the component unmounts.
   const mounted = useRef(true)
   useEffect(
     () => () => {
@@ -54,20 +55,21 @@ export function useHaushaltsredenEditor(): HaushaltsredenEditorState {
     },
     [],
   )
-  useEffect(() => {
-    latestDisabled.current = disabledYears
-  }, [disabledYears])
+
+  // Derive disabledYears from store state so dirty-tracking and revert work automatically.
+  const disabledYears = useMemo(
+    () => new Set<number>(storeData?.disabledYears ?? []),
+    [storeData],
+  )
 
   // ─── Load ────────────────────────────────────────────────────────────────────
+  // Only fetches the PDF directory list — the config JSON is loaded by the store.
 
   const load = useCallback(
     async (opts: { silent?: boolean; signal?: { cancelled: boolean } } = {}) => {
       const { silent = false, signal } = opts
       try {
-        const [files, config] = await Promise.all([
-          listDirectory('public/documents/fraktion/haushaltsreden'),
-          getFileContent('public/data/haushaltsreden.json'),
-        ])
+        const files = await listDirectory('public/documents/fraktion/haushaltsreden')
         if (signal?.cancelled) return
         const map: Record<number, string> = {}
         for (const f of files) {
@@ -75,7 +77,6 @@ export function useHaushaltsredenEditor(): HaushaltsredenEditorState {
           if (m) map[parseInt(m[1])] = f.sha
         }
         setExistingMap(map)
-        if (config?.disabledYears) setDisabledYears(new Set(config.disabledYears))
         if (!silent) {
           setLoadError(false)
           setLoading(false)
@@ -83,8 +84,6 @@ export function useHaushaltsredenEditor(): HaushaltsredenEditorState {
       } catch {
         if (signal?.cancelled) return
         if (silent) {
-          // Surface background-refresh failures as a non-blocking toast instead
-          // of silently leaving the grid with potentially stale data.
           setStatus('Aktualisierung fehlgeschlagen — Ansicht möglicherweise veraltet.', 'error')
         } else {
           setLoadError(true)
@@ -110,49 +109,20 @@ export function useHaushaltsredenEditor(): HaushaltsredenEditorState {
     void load()
   }, [load])
 
-  // ─── Save config ─────────────────────────────────────────────────────────────
-
-  // Memoized so toggleYear's useCallback dependency stays stable across renders.
-  const saveConfig = useCallback(async (disabled: Set<number>) => {
-    const body = { disabledYears: [...disabled].sort((a, b) => a - b) }
-    await commitFile(
-      'public/data/haushaltsreden.json',
-      JSON.stringify(body, null, 2) + '\n',
-      'admin: Haushaltsreden-Konfiguration aktualisiert',
-    )
-  }, [])
-
   // ─── Actions ─────────────────────────────────────────────────────────────────
 
+  // Toggle marks the tab dirty via the store instead of committing immediately.
+  // The user must click "Veröffentlichen" to persist the change, exactly like
+  // every other admin tab.
   const toggleYear = useCallback(
     (year: number) => {
-      toggleQueue.current = toggleQueue.current.then(async () => {
-        if (!mounted.current) return
-        const prev = latestDisabled.current
-        const next = new Set(prev)
-        if (next.has(year)) next.delete(year)
-        else next.add(year)
-        setDisabledYears(next)
-        latestDisabled.current = next
-        setBusy(year)
-        try {
-          await saveConfig(next)
-          if (!mounted.current) return
-          setStatus(
-            `${year} ${next.has(year) ? 'ausgeblendet' : 'eingeblendet'} & gespeichert`,
-            'success',
-          )
-        } catch (e) {
-          if (!mounted.current) return
-          setDisabledYears(prev)
-          latestDisabled.current = prev
-          setStatus('Fehler: ' + (e as Error).message, 'error')
-        } finally {
-          if (mounted.current) setBusy(null)
-        }
-      })
+      const prev = new Set<number>(storeData?.disabledYears ?? [])
+      const next = new Set(prev)
+      if (next.has(year)) next.delete(year)
+      else next.add(year)
+      updateState('haushaltsreden', { disabledYears: [...next].sort((a, b) => a - b) })
     },
-    [saveConfig, setStatus],
+    [storeData, updateState],
   )
 
   const uploadPdf = useCallback(
@@ -203,13 +173,11 @@ export function useHaushaltsredenEditor(): HaushaltsredenEditorState {
     [ensureAuthenticated, load, setStatus],
   )
 
-  // Intent-based delete dialog actions — hides the raw state setter from callers.
   const requestDelete = useCallback((year: number) => setConfirmDeleteYear(year), [])
   const cancelDelete = useCallback(() => setConfirmDeleteYear(null), [])
 
   // ─── Derived values ───────────────────────────────────────────────────────────
 
-  // Stable for the lifetime of the session — no need to recompute on every render.
   const currentYear = useMemo(() => new Date().getFullYear(), [])
   const allYears = useMemo(
     () => Array.from({ length: currentYear + 1 - 2010 }, (_, i) => currentYear - i),


### PR DESCRIPTION
The Aus/Ein toggle previously committed directly to GitHub on every click, bypassing dirty tracking and the Veröffentlichen button.

- Give the tab a `file` + `ghPath` so the store loads the JSON and tracks changes
- `toggleYear` now calls `updateState()` → marks tab dirty → red dot + publish button appear like every other tab
- `disabledYears` derived from store state, so revert and diff in PublishConfirmModal work for free
- Remove `saveConfig`, `toggleQueue`, `latestDisabled` — only existed to handle the async GitHub commit race condition
- PDF upload/delete remain immediate operations (unchanged)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFYvCGhi5ecA78zygDFhgP)_