### PR TITLE
Fix Haushaltsreden diff display and PDF service worker issue

### DIFF
--- a/src/admin/components/GlobalDiffModal.tsx
+++ b/src/admin/components/GlobalDiffModal.tsx
@@ -40,7 +40,7 @@ export default function GlobalDiffModal({ onClose }: Props) {
     const pendingImagePaths = new Set(pendingUploads.map(u => u.ghPath.replace(/^public/, '')))
     const result: TabChanges[] = []
     for (const tab of TABS) {
-      if (!tab.file || tab.type === 'haushaltsreden') continue
+      if (!tab.file) continue
       const entries = diffTab(
         tab as TabConfig,
         originalState[tab.key],

--- a/src/admin/components/PublishConfirmModal.tsx
+++ b/src/admin/components/PublishConfirmModal.tsx
@@ -35,7 +35,7 @@ export default function PublishConfirmModal({ tabKey, onConfirm, onCancel }: Pro
     const result: { tab: TabConfig; entries: ChangeEntry[]; groups: ChangeGroup[] }[] = []
     const tabs = tabKey ? TABS.filter(t => t.key === tabKey) : TABS
     for (const tab of tabs) {
-      if (!tab.file || tab.type === 'haushaltsreden') continue
+      if (!tab.file) continue
       const entries = diffTab(
         tab as TabConfig,
         originalState[tab.key],

--- a/src/admin/lib/diff.ts
+++ b/src/admin/lib/diff.ts
@@ -254,7 +254,45 @@ export function diffTab(
   pendingImagePaths?: Set<string>,
 ): ChangeEntry[] {
   const out: ChangeEntry[] = []
-  if (tab.type === 'haushaltsreden') return out
+  if (tab.type === 'haushaltsreden') {
+    const origYears = new Set<number>(
+      (original as { disabledYears?: number[] } | null)?.disabledYears ?? [],
+    )
+    const currYears = new Set<number>(
+      (current as { disabledYears?: number[] } | null)?.disabledYears ?? [],
+    )
+    for (const year of currYears) {
+      if (!origYears.has(year)) {
+        out.push({
+          id: `disabledYears.${year}:hidden`,
+          path: ['disabledYears'],
+          kind: 'modified',
+          group: 'Sichtbarkeit',
+          fieldKey: 'disabledYears',
+          fieldLabel: String(year),
+          fieldType: 'text',
+          before: 'Sichtbar',
+          after: 'Ausgeblendet',
+        })
+      }
+    }
+    for (const year of origYears) {
+      if (!currYears.has(year)) {
+        out.push({
+          id: `disabledYears.${year}:shown`,
+          path: ['disabledYears'],
+          kind: 'modified',
+          group: 'Sichtbarkeit',
+          fieldKey: 'disabledYears',
+          fieldLabel: String(year),
+          fieldType: 'text',
+          before: 'Ausgeblendet',
+          after: 'Sichtbar',
+        })
+      }
+    }
+    return out
+  }
 
   if (tab.type === 'kommunalpolitik') {
     const orig = (original ?? {}) as Record<string, unknown>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -89,7 +89,7 @@ export default defineConfig(({ mode }) => {
           // It will be cached on first access to /admin via the navigation handler.
           globIgnores: ['**/AdminApp*.js', '**/admin*.js'],
           navigateFallback: '/index.html',
-          navigateFallbackDenylist: [/^\/api\//, /^\/data\//, /^\/admin/],
+          navigateFallbackDenylist: [/^\/api\//, /^\/data\//, /^\/admin/, /^\/documents\//, /\.pdf$/i],
           runtimeCaching: [
             {
               urlPattern: /^https:\/\/static\.elfsight\.com\/.*/i,


### PR DESCRIPTION
Two fixes in one branch:

**Haushaltsreden changes now appear in Alle Änderungen / publish modal**
- `diff.ts`: replace the early-return bail-out with a real diff that emits one entry per changed year (e.g. "2020: Sichtbar → Ausgeblendet")
- `PublishConfirmModal` + `GlobalDiffModal`: remove the `tab.type === 'haushaltsreden'` skip guards left over from before the tab was file-backed

**PDF links no longer open the app instead of the file**
- The service worker's `navigateFallbackDenylist` was missing `/documents/` and `.pdf`, so Workbox intercepted PDF navigation requests and served `index.html` — causing the "can't find PDF" error in the Fraktion section

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFYvCGhi5ecA78zygDFhgP)_