### PR TITLE
Admin UI polish: sidebar, tab header, login page redesign

### DIFF
--- a/src/admin/AdminApp.tsx
+++ b/src/admin/AdminApp.tsx
@@ -133,7 +133,12 @@ export default function AdminApp() {
   }
 
   return (
-    <div className="min-h-screen bg-linear-to-br from-gray-50 via-gray-50 to-gray-100 dark:from-gray-950 dark:via-gray-950 dark:to-gray-900 text-gray-900 dark:text-gray-100 transition-colors text-left [hyphens:none]">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950 text-gray-900 dark:text-gray-100 transition-colors text-left [hyphens:none]">
+      {/* Ambient background decorations */}
+      <div className="fixed inset-0 pointer-events-none -z-10 overflow-hidden">
+        <div className="absolute -top-48 -right-48 w-[700px] h-[700px] bg-spd-red/[0.03] dark:bg-spd-red/[0.06] rounded-full blur-3xl" />
+        <div className="absolute -bottom-32 -left-32 w-[500px] h-[500px] bg-spd-red/[0.02] dark:bg-spd-red/[0.04] rounded-full blur-3xl" />
+      </div>
       <Toaster position="top-right" richColors closeButton theme={darkMode ? 'dark' : 'light'} />
 
       {/* Global modals */}
@@ -190,24 +195,27 @@ export default function AdminApp() {
       {/* Main content area */}
       <div className="lg:pl-64">
         {/* Top bar for mobile */}
-        <header className="lg:hidden sticky top-0 z-30 bg-white/80 dark:bg-gray-900/80 backdrop-blur-xl border-b border-gray-200/60 dark:border-gray-800/60">
+        <header className="lg:hidden sticky top-0 z-30 bg-white/90 dark:bg-gray-950/90 backdrop-blur-xl border-b border-gray-200/60 dark:border-gray-800/60 shadow-sm">
+          <div className="absolute top-0 left-0 right-0 h-0.5 bg-gradient-to-r from-spd-red via-spd-red/50 to-transparent" />
           <div className="flex items-center justify-between px-4 py-3">
             <button
               type="button"
               onClick={() => setSidebarOpen(true)}
               aria-label="Seitenleiste öffnen"
-              className="w-9 h-9 rounded-xl bg-gray-100 dark:bg-gray-800 flex items-center justify-center text-gray-600 dark:text-gray-400"
+              className="w-9 h-9 rounded-xl bg-gray-100 dark:bg-gray-800/80 flex items-center justify-center text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
             >
               <Menu size={18} />
             </button>
-            <div className="flex items-center gap-2">
-              <div className="w-8 h-8 rounded-xl overflow-hidden">
-                <img src="/spd-logo.svg" alt="SPD" className="w-full h-full" />
+            <div className="flex items-center gap-2.5">
+              <div className="relative">
+                <div className="absolute inset-0 bg-spd-red/20 rounded-xl blur-sm" />
+                <div className="relative w-7 h-7 rounded-xl overflow-hidden shadow-sm">
+                  <img src="/spd-logo.svg" alt="SPD" className="w-full h-full" />
+                </div>
               </div>
-              <span className="font-bold text-sm dark:text-white">Editor</span>
+              <span className="font-bold text-sm dark:text-white tracking-tight">Daten-Editor</span>
             </div>
             <div className="w-9" />
-            {/* Spacer */}
           </div>
         </header>
 
@@ -252,27 +260,37 @@ export default function AdminApp() {
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.25 }}
             >
-              <div className="flex items-center gap-3 mb-2">
-                <div className="w-10 h-10 rounded-xl bg-linear-to-br from-spd-red/10 to-spd-red/5 dark:from-spd-red/20 dark:to-spd-red/10 flex items-center justify-center text-spd-red">
-                  {getTabIcon(currentTab.key)}
-                </div>
-                <div>
-                  <h2 className="text-xl sm:text-2xl font-extrabold dark:text-white tracking-tight">
-                    {currentTab.label}
-                  </h2>
-                  <p className="text-xs text-gray-400 font-medium flex items-center gap-1">
-                    Direkt-Bearbeitung — Veröffentlichung per Klick
-                  </p>
-                </div>
-                {/* Other users on this tab */}
-                {usersOnCurrentTab.length > 0 && (
-                  <div className="ml-auto flex items-center gap-2">
-                    <PresenceBadge users={usersOnCurrentTab} />
-                    <span className="text-[10px] text-gray-400 hidden sm:block">
-                      {usersOnCurrentTab.map(u => u.login).join(', ')} bearbeitet gerade
-                    </span>
+              <div className="relative rounded-2xl bg-white/70 dark:bg-gray-900/50 border border-gray-200/70 dark:border-gray-800/60 shadow-sm overflow-hidden mb-4">
+                {/* Top accent stripe */}
+                <div className="absolute top-0 left-0 right-0 h-0.5 bg-gradient-to-r from-spd-red via-spd-red/40 to-transparent" />
+                {/* Background gradient wash */}
+                <div className="absolute inset-0 bg-gradient-to-br from-spd-red/[0.04] via-transparent to-transparent dark:from-spd-red/[0.08] pointer-events-none" />
+                <div className="relative flex items-center gap-4 px-5 py-4 sm:px-6 sm:py-5">
+                  {/* Tab icon */}
+                  <div className="relative shrink-0">
+                    <div className="absolute inset-0 bg-spd-red/15 dark:bg-spd-red/20 rounded-2xl blur-md" />
+                    <div className="relative w-12 h-12 rounded-2xl bg-gradient-to-br from-spd-red/12 to-spd-red/4 dark:from-spd-red/20 dark:to-spd-red/8 flex items-center justify-center text-spd-red ring-1 ring-spd-red/10 dark:ring-spd-red/20 shadow-sm">
+                      <span className="scale-110">{getTabIcon(currentTab.key)}</span>
+                    </div>
                   </div>
-                )}
+                  <div className="flex-1 min-w-0">
+                    <h2 className="text-xl sm:text-2xl font-extrabold dark:text-white tracking-tight leading-none mb-1">
+                      {currentTab.label}
+                    </h2>
+                    <p className="text-xs text-gray-400 dark:text-gray-500 font-medium">
+                      Direkt-Bearbeitung · Veröffentlichung per Klick
+                    </p>
+                  </div>
+                  {/* Other users on this tab */}
+                  {usersOnCurrentTab.length > 0 && (
+                    <div className="flex items-center gap-2">
+                      <PresenceBadge users={usersOnCurrentTab} />
+                      <span className="text-[10px] text-gray-400 hidden sm:block">
+                        {usersOnCurrentTab.map(u => u.login).join(', ')} bearbeitet gerade
+                      </span>
+                    </div>
+                  )}
+                </div>
               </div>
               {/* Tab locked warning */}
               {usersOnCurrentTab.some(u => u.dirtyTabs.includes(activeTab)) && (

--- a/src/admin/components/AdminSidebar.tsx
+++ b/src/admin/components/AdminSidebar.tsx
@@ -80,26 +80,33 @@ export default function AdminSidebar({
         onTouchEnd={handleTouchEnd}
         className={`fixed top-0 left-0 h-full w-64 z-50 flex flex-col transition-transform duration-300 lg:translate-x-0 ${open ? 'translate-x-0' : '-translate-x-full'}`}
       >
-        <div className="flex flex-col h-full bg-white/80 dark:bg-gray-900/80 backdrop-blur-xl border-r border-gray-200/60 dark:border-gray-800/60">
+        <div className="flex flex-col h-full bg-white/85 dark:bg-gray-900/85 backdrop-blur-xl border-r border-gray-200/60 dark:border-gray-800/60">
           {/* Logo area */}
-          <div className="p-5 pb-4">
-            <div className="flex items-center gap-3">
-              <div className="w-10 h-10 rounded-2xl shadow-lg shadow-spd-red/25 overflow-hidden">
-                <img src="/spd-logo.svg" alt="SPD" className="w-full h-full" />
+          <div className="relative px-5 pt-5 pb-4 overflow-hidden">
+            {/* Accent line at top */}
+            <div className="absolute top-0 left-0 right-0 h-0.5 bg-gradient-to-r from-spd-red via-spd-red/50 to-transparent" />
+            {/* Subtle gradient wash */}
+            <div className="absolute inset-0 bg-gradient-to-b from-spd-red/5 dark:from-spd-red/10 to-transparent pointer-events-none" />
+            <div className="relative flex items-center gap-3">
+              <div className="relative shrink-0">
+                <div className="absolute inset-0 bg-spd-red/20 rounded-2xl blur-md" />
+                <div className="relative w-10 h-10 rounded-2xl shadow-lg shadow-spd-red/30 overflow-hidden ring-1 ring-spd-red/10 dark:ring-spd-red/20">
+                  <img src="/spd-logo.svg" alt="SPD" className="w-full h-full" />
+                </div>
               </div>
-              <div>
-                <h1 className="font-extrabold text-sm dark:text-white tracking-tight">
+              <div className="flex-1 min-w-0">
+                <h1 className="font-extrabold text-sm dark:text-white tracking-tight leading-none mb-0.5">
                   Daten-Editor
                 </h1>
-                <p className="text-[10px] text-gray-400 font-medium">SPD Albstadt</p>
+                <p className="text-[10px] text-gray-400 dark:text-gray-500 font-medium">SPD Albstadt</p>
               </div>
               <button
                 type="button"
                 onClick={onClose}
                 aria-label="Seitenleiste schließen"
-                className="ml-auto lg:hidden text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+                className="lg:hidden w-7 h-7 rounded-lg flex items-center justify-center text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
               >
-                <X size={18} />
+                <X size={16} />
               </button>
             </div>
           </div>

--- a/src/admin/components/LoginScreen.tsx
+++ b/src/admin/components/LoginScreen.tsx
@@ -127,7 +127,7 @@ export default function LoginScreen() {
               </div>
             </div>
             <div>
-              <p className="font-extrabold text-sm dark:text-white tracking-tight">Daten-Editor</p>
+              <p className="font-extrabold text-sm text-gray-900 dark:text-white tracking-tight">Daten-Editor</p>
               <p className="text-[10px] text-gray-400">SPD Albstadt</p>
             </div>
           </div>
@@ -135,7 +135,7 @@ export default function LoginScreen() {
           <p className="text-xs font-semibold text-spd-red uppercase tracking-widest mb-2">
             Administration
           </p>
-          <h2 className="text-3xl font-extrabold dark:text-white tracking-tight mb-1.5">
+          <h2 className="text-3xl font-extrabold text-gray-900 dark:text-white tracking-tight mb-1.5">
             Willkommen zurück
           </h2>
           <p className="text-sm text-gray-500 dark:text-gray-400 mb-8 leading-relaxed">
@@ -177,7 +177,7 @@ export default function LoginScreen() {
             </div>
           )}
 
-          <div className="mt-8 pt-6 border-t border-gray-100 dark:border-gray-800/60 flex items-center gap-2 text-[10px] text-gray-400 dark:text-gray-600">
+          <div className="mt-8 pt-6 border-t border-gray-100 dark:border-gray-800/60 flex items-center gap-2 text-[10px] text-gray-400 dark:text-gray-500">
             <Shield size={10} className="shrink-0" />
             <span>OAuth 2.0 · Nur GitHub API · HttpOnly Cookies</span>
           </div>

--- a/src/admin/components/LoginScreen.tsx
+++ b/src/admin/components/LoginScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Loader2, Shield } from 'lucide-react'
+import { Loader2, Moon, Shield, Sun } from 'lucide-react'
 import { motion } from 'framer-motion'
 import { useNavigate } from 'react-router-dom'
 import { useAdminStore } from '../store'
@@ -19,7 +19,7 @@ function GitHubMark({ size = 18 }: { size?: number }) {
 const CLIENT_ID = import.meta.env.VITE_GITHUB_CLIENT_ID as string | undefined
 
 export default function LoginScreen() {
-  const { login, loginError, loginLoading, loginAuthStatus } = useAdminStore()
+  const { login, loginError, loginLoading, loginAuthStatus, darkMode, toggleDark } = useAdminStore()
   const navigate = useNavigate()
 
   const [authResult] = useState(() => {
@@ -101,6 +101,16 @@ export default function LoginScreen() {
         <div className="absolute inset-0 bg-gradient-to-br from-gray-50 via-white to-gray-50/80 dark:from-gray-950 dark:via-gray-950 dark:to-gray-900" />
         <div className="absolute -top-48 -right-48 w-[600px] h-[600px] bg-spd-red/[0.04] dark:bg-spd-red/[0.08] rounded-full blur-3xl" />
         <div className="absolute -bottom-32 -left-32 w-80 h-80 bg-spd-red/[0.02] dark:bg-spd-red/[0.05] rounded-full blur-3xl" />
+
+        {/* Dark mode toggle */}
+        <button
+          type="button"
+          onClick={toggleDark}
+          aria-label={darkMode ? 'Helles Design aktivieren' : 'Dunkles Design aktivieren'}
+          className="absolute top-4 right-4 w-9 h-9 rounded-xl bg-gray-100 dark:bg-gray-800/80 flex items-center justify-center text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+        >
+          {darkMode ? <Sun size={15} /> : <Moon size={15} />}
+        </button>
 
         <motion.div
           initial={{ opacity: 0, y: 18, scale: 0.97 }}

--- a/src/admin/components/LoginScreen.tsx
+++ b/src/admin/components/LoginScreen.tsx
@@ -22,12 +22,10 @@ export default function LoginScreen() {
   const { login, loginError, loginLoading, loginAuthStatus } = useAdminStore()
   const navigate = useNavigate()
 
-  // Parse the OAuth callback query params once at mount
   const [authResult] = useState(() => {
     const params = new URLSearchParams(window.location.search)
     const auth = params.get('auth')
     if (!auth) return { error: '', ok: false }
-    // Clean URL immediately
     window.history.replaceState(null, '', window.location.pathname)
     if (auth === 'error') {
       const msg = params.get('msg') || 'unknown_error'
@@ -38,11 +36,8 @@ export default function LoginScreen() {
 
   const [oauthError, setOauthError] = useState(authResult.error)
 
-  // When callback succeeded, fetch session from server and login
   useEffect(() => {
-    if (authResult.ok) {
-      login()
-    }
+    if (authResult.ok) login()
   }, [authResult.ok, login])
 
   useEffect(() => {
@@ -54,38 +49,87 @@ export default function LoginScreen() {
   const handleGitHubLogin = () => {
     if (!CLIENT_ID) return
     setOauthError('')
-    // Redirect to server-side start endpoint which handles state, scope & cookies
     window.location.href = '/api/auth/start'
   }
 
   const errorMsg = loginError || oauthError
 
   return (
-    <div className="min-h-screen flex items-center justify-center px-4 bg-linear-to-br from-gray-50 via-white to-gray-100 dark:from-gray-950 dark:via-gray-900 dark:to-gray-950 relative overflow-hidden text-left [hyphens:none]">
-      <div className="absolute inset-0 overflow-hidden pointer-events-none">
-        <div className="absolute -top-40 -right-40 w-96 h-96 bg-spd-red/5 dark:bg-spd-red/10 rounded-full blur-3xl" />
-        <div className="absolute -bottom-40 -left-40 w-96 h-96 bg-spd-red/3 dark:bg-spd-red/5 rounded-full blur-3xl" />
-      </div>
+    <div className="min-h-screen flex flex-col lg:flex-row text-left [hyphens:none]">
 
-      <motion.div
-        initial={{ opacity: 0, y: 20, scale: 0.97 }}
-        animate={{ opacity: 1, y: 0, scale: 1 }}
-        transition={{ duration: 0.5, ease: 'easeOut' }}
-        className="relative"
-      >
-        <div className="bg-white/70 dark:bg-gray-900/70 backdrop-blur-2xl rounded-3xl shadow-2xl dark:shadow-black/40 p-8 sm:p-10 w-full max-w-md text-center border border-white/50 dark:border-gray-700/50">
-          <div className="relative mx-auto mb-8 w-fit">
-            <div className="absolute inset-0 bg-spd-red/20 rounded-3xl blur-xl scale-150" />
-            <div className="relative w-16 h-16 rounded-2xl shadow-xl shadow-spd-red/30 overflow-hidden">
-              <img src="/spd-logo.svg" alt="SPD" className="w-full h-full" />
+      {/* ── Left branding panel (desktop only) ─────────────────────────── */}
+      <div className="hidden lg:flex lg:w-[420px] xl:w-[480px] shrink-0 flex-col justify-between p-10 xl:p-14 relative overflow-hidden bg-gray-950">
+        {/* Grid pattern */}
+        <div className="absolute inset-0 bg-[linear-gradient(to_right,rgba(255,255,255,0.025)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.025)_1px,transparent_1px)] bg-[size:36px_36px]" />
+        {/* Radial glows */}
+        <div className="absolute -top-32 -right-32 w-[500px] h-[500px] bg-spd-red/15 rounded-full blur-3xl" />
+        <div className="absolute -bottom-32 -left-32 w-[400px] h-[400px] bg-spd-red/8 rounded-full blur-3xl" />
+        {/* Top accent line */}
+        <div className="absolute top-0 left-0 right-0 h-0.5 bg-gradient-to-r from-spd-red via-spd-red/60 to-transparent" />
+        {/* Right edge fade */}
+        <div className="absolute top-0 right-0 bottom-0 w-px bg-gradient-to-b from-transparent via-white/5 to-transparent" />
+
+        {/* Top: logo + wordmark */}
+        <div className="relative z-10">
+          <div className="relative w-fit mb-10">
+            <div className="absolute inset-0 bg-spd-red/25 rounded-3xl blur-2xl scale-[2.5]" />
+            <div className="relative w-16 h-16 rounded-2xl overflow-hidden shadow-2xl shadow-spd-red/40 ring-1 ring-white/10">
+              <img src="/spd-logo.svg" alt="SPD Albstadt" className="w-full h-full" />
             </div>
           </div>
 
-          <h1 className="text-2xl font-extrabold mb-1 dark:text-white tracking-tight">
-            Daten-Editor
+          <h1 className="text-4xl xl:text-5xl font-black text-white tracking-tight leading-[1.05] mb-4">
+            Daten-<br />Editor
           </h1>
+          <p className="text-gray-400 text-sm leading-relaxed max-w-[260px]">
+            Inhalte bearbeiten, Fotos hochladen und Änderungen direkt auf spd-albstadt.de veröffentlichen.
+          </p>
+        </div>
+
+        {/* Bottom: version / org */}
+        <div className="relative z-10 flex items-center gap-2">
+          <div className="w-1.5 h-1.5 rounded-full bg-spd-red/60" />
+          <p className="text-[11px] text-gray-600 font-medium tracking-wide uppercase">
+            SPD Ortsverein Albstadt
+          </p>
+        </div>
+      </div>
+
+      {/* ── Right login panel ───────────────────────────────────────────── */}
+      <div className="flex-1 flex items-center justify-center px-6 py-16 relative overflow-hidden bg-white dark:bg-gray-950">
+        {/* Background */}
+        <div className="absolute inset-0 bg-gradient-to-br from-gray-50 via-white to-gray-50/80 dark:from-gray-950 dark:via-gray-950 dark:to-gray-900" />
+        <div className="absolute -top-48 -right-48 w-[600px] h-[600px] bg-spd-red/[0.04] dark:bg-spd-red/[0.08] rounded-full blur-3xl" />
+        <div className="absolute -bottom-32 -left-32 w-80 h-80 bg-spd-red/[0.02] dark:bg-spd-red/[0.05] rounded-full blur-3xl" />
+
+        <motion.div
+          initial={{ opacity: 0, y: 18, scale: 0.97 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          transition={{ duration: 0.45, ease: [0.22, 1, 0.36, 1] }}
+          className="relative w-full max-w-sm"
+        >
+          {/* Mobile logo (hidden on desktop) */}
+          <div className="flex items-center gap-3 mb-10 lg:hidden">
+            <div className="relative">
+              <div className="absolute inset-0 bg-spd-red/20 rounded-xl blur-md" />
+              <div className="relative w-10 h-10 rounded-xl overflow-hidden shadow-lg shadow-spd-red/20 ring-1 ring-spd-red/10">
+                <img src="/spd-logo.svg" alt="SPD" className="w-full h-full" />
+              </div>
+            </div>
+            <div>
+              <p className="font-extrabold text-sm dark:text-white tracking-tight">Daten-Editor</p>
+              <p className="text-[10px] text-gray-400">SPD Albstadt</p>
+            </div>
+          </div>
+
+          <p className="text-xs font-semibold text-spd-red uppercase tracking-widest mb-2">
+            Administration
+          </p>
+          <h2 className="text-3xl font-extrabold dark:text-white tracking-tight mb-1.5">
+            Willkommen zurück
+          </h2>
           <p className="text-sm text-gray-500 dark:text-gray-400 mb-8 leading-relaxed">
-            Melden Sie sich mit Ihrem GitHub-Konto an, um Inhalte zu bearbeiten.
+            Melden Sie sich mit Ihrem GitHub-Konto an, um Inhalte zu verwalten.
           </p>
 
           {!CLIENT_ID ? (
@@ -94,12 +138,12 @@ export default function LoginScreen() {
               <code className="font-mono">VITE_GITHUB_CLIENT_ID</code> ist nicht gesetzt.
             </div>
           ) : (
-            <div className="space-y-4">
+            <div className="space-y-3">
               {errorMsg && (
                 <motion.p
                   initial={{ opacity: 0, y: -4 }}
                   animate={{ opacity: 1, y: 0 }}
-                  className="text-xs text-red-500 text-left bg-red-50 dark:bg-red-900/20 px-3 py-2 rounded-xl"
+                  className="text-xs text-red-500 bg-red-50 dark:bg-red-900/20 px-3 py-2.5 rounded-xl border border-red-100 dark:border-red-900/40"
                 >
                   {errorMsg}
                 </motion.p>
@@ -109,25 +153,26 @@ export default function LoginScreen() {
                 type="button"
                 onClick={handleGitHubLogin}
                 disabled={loginLoading}
-                className="w-full bg-gray-900 dark:bg-white/10 hover:bg-gray-800 dark:hover:bg-white/15 text-white font-bold py-4 rounded-2xl hover:shadow-xl hover:scale-[1.01] active:scale-[0.99] transition-all duration-200 flex items-center justify-center gap-2.5 disabled:opacity-50 disabled:hover:shadow-none disabled:hover:scale-100"
+                className="w-full group relative bg-gray-950 dark:bg-white/8 hover:bg-gray-800 dark:hover:bg-white/12 text-white font-bold py-3.5 rounded-2xl transition-all duration-200 flex items-center justify-center gap-3 disabled:opacity-50 disabled:pointer-events-none shadow-lg shadow-black/10 dark:shadow-black/30 hover:shadow-xl hover:shadow-black/15 hover:scale-[1.01] active:scale-[0.99]"
               >
                 {loginLoading ? (
                   <Loader2 size={18} className="animate-spin" />
                 ) : (
                   <>
-                    <GitHubMark size={18} /> Mit GitHub anmelden
+                    <GitHubMark size={18} />
+                    <span>Mit GitHub anmelden</span>
                   </>
                 )}
               </button>
             </div>
           )}
 
-          <div className="mt-6 flex items-center gap-2 justify-center text-[10px] text-gray-400">
-            <Shield size={10} />
+          <div className="mt-8 pt-6 border-t border-gray-100 dark:border-gray-800/60 flex items-center gap-2 text-[10px] text-gray-400 dark:text-gray-600">
+            <Shield size={10} className="shrink-0" />
             <span>OAuth 2.0 · Nur GitHub API · HttpOnly Cookies</span>
           </div>
-        </div>
-      </motion.div>
+        </motion.div>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Three improvements bundled:

**Sidebar & main content polish**
- Sidebar: red gradient accent line at top, gradient wash behind logo, glow on SPD logo
- Tab header becomes a proper glass card with accent stripe, gradient wash, and icon glow
- Mobile top bar: matching accent stripe and logo glow
- Ambient radial gradients in the page background

**Login page redesign**
- Split-panel layout: dark branded left side (grid pattern, radial glows, large logo, headline) + clean login form on the right
- Dark/light mode toggle button added to login page (was previously inaccessible before authentication)
- "Willkommen zurück" heading, red eyebrow label, security footer with divider

**Login page light mode fixes**
- Heading and mobile logo label were missing `text-gray-900` for light mode
- Security footer colours were swapped (`dark:text-gray-600` near-invisible on dark bg)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFYvCGhi5ecA78zygDFhgP)_