### PR TITLE
Remove border radius from admin logos (squared)

### DIFF
--- a/src/admin/AdminApp.tsx
+++ b/src/admin/AdminApp.tsx
@@ -208,8 +208,8 @@ export default function AdminApp() {
             </button>
             <div className="flex items-center gap-2.5">
               <div className="relative">
-                <div className="absolute inset-0 bg-spd-red/20 rounded-xl blur-sm" />
-                <div className="relative w-7 h-7 rounded-xl overflow-hidden shadow-sm">
+                <div className="absolute inset-0 bg-spd-red/20 blur-sm" />
+                <div className="relative w-7 h-7 overflow-hidden shadow-sm">
                   <img src="/spd-logo.svg" alt="SPD" className="w-full h-full" />
                 </div>
               </div>

--- a/src/admin/components/AdminSidebar.tsx
+++ b/src/admin/components/AdminSidebar.tsx
@@ -89,8 +89,8 @@ export default function AdminSidebar({
             <div className="absolute inset-0 bg-gradient-to-b from-spd-red/5 dark:from-spd-red/10 to-transparent pointer-events-none" />
             <div className="relative flex items-center gap-3">
               <div className="relative shrink-0">
-                <div className="absolute inset-0 bg-spd-red/20 rounded-2xl blur-md" />
-                <div className="relative w-10 h-10 rounded-2xl shadow-lg shadow-spd-red/30 overflow-hidden ring-1 ring-spd-red/10 dark:ring-spd-red/20">
+                <div className="absolute inset-0 bg-spd-red/20 blur-md" />
+                <div className="relative w-10 h-10 shadow-lg shadow-spd-red/30 overflow-hidden ring-1 ring-spd-red/10 dark:ring-spd-red/20">
                   <img src="/spd-logo.svg" alt="SPD" className="w-full h-full" />
                 </div>
               </div>

--- a/src/admin/components/LoginScreen.tsx
+++ b/src/admin/components/LoginScreen.tsx
@@ -72,8 +72,8 @@ export default function LoginScreen() {
         {/* Top: logo + wordmark */}
         <div className="relative z-10">
           <div className="relative w-fit mb-10">
-            <div className="absolute inset-0 bg-spd-red/25 rounded-3xl blur-2xl scale-[2.5]" />
-            <div className="relative w-16 h-16 rounded-2xl overflow-hidden shadow-2xl shadow-spd-red/40 ring-1 ring-white/10">
+            <div className="absolute inset-0 bg-spd-red/25 blur-2xl scale-[2.5]" />
+            <div className="relative w-16 h-16 overflow-hidden shadow-2xl shadow-spd-red/40 ring-1 ring-white/10">
               <img src="/spd-logo.svg" alt="SPD Albstadt" className="w-full h-full" />
             </div>
           </div>
@@ -121,8 +121,8 @@ export default function LoginScreen() {
           {/* Mobile logo (hidden on desktop) */}
           <div className="flex items-center gap-3 mb-10 lg:hidden">
             <div className="relative">
-              <div className="absolute inset-0 bg-spd-red/20 rounded-xl blur-md" />
-              <div className="relative w-10 h-10 rounded-xl overflow-hidden shadow-lg shadow-spd-red/20 ring-1 ring-spd-red/10">
+              <div className="absolute inset-0 bg-spd-red/20 blur-md" />
+              <div className="relative w-10 h-10 overflow-hidden shadow-lg shadow-spd-red/20 ring-1 ring-spd-red/10">
                 <img src="/spd-logo.svg" alt="SPD" className="w-full h-full" />
               </div>
             </div>


### PR DESCRIPTION
Removes all `rounded-*` classes from SPD logo containers and their glow divs across the admin UI, making logos appear as squares instead of rounded rectangles.

Affected locations:
- `AdminSidebar.tsx` — sidebar logo
- `LoginScreen.tsx` — left panel logo (desktop) and mobile logo
- `AdminApp.tsx` — mobile top bar logo

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFYvCGhi5ecA78zygDFhgP)_