### PR TITLE
Remove border radius from homepage logos (squared)

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -43,7 +43,7 @@ export default function Footer() {
           {/* Brand */}
           <div>
             <div className="flex items-center gap-3 mb-4">
-              <img src="/spd-logo.svg" alt="SPD" className="w-10 h-10 rounded-xl shadow-lg" />
+              <img src="/spd-logo.svg" alt="SPD" className="w-10 h-10 shadow-lg" />
               <span className="font-black text-white text-xl tracking-tight">Albstadt</span>
             </div>
             <p className="text-sm leading-relaxed mb-4 max-w-xs">{beschreibung}</p>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -38,7 +38,7 @@ export default function Navbar() {
               <img
                 src="/spd-logo.svg"
                 alt="SPD"
-                className="w-9 h-9 rounded-lg shadow-md group-hover:scale-105 transition-transform"
+                className="w-9 h-9 shadow-md group-hover:scale-105 transition-transform"
               />
               {!isHome && (
                 <span className="font-bold text-lg tracking-tight transition-colors duration-300 text-gray-900 dark:text-white">


### PR DESCRIPTION
Removes `rounded-lg` / `rounded-xl` from the SPD logo in `Navbar.tsx` and `Footer.tsx`, making them appear as squares on the public site — consistent with the admin logo change in #47.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFYvCGhi5ecA78zygDFhgP)_