### PR TITLE
Simplify admin UI: ModalFrame, TabEditorShell, consistent z-index

### DIFF
--- a/src/admin/components/ConflictMergeModal.tsx
+++ b/src/admin/components/ConflictMergeModal.tsx
@@ -54,7 +54,7 @@ export default function ConflictMergeModal({ tabKey, conflicts, onClose }: Props
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+    <div className="fixed inset-0 z-[9999] flex items-center justify-center p-4">
       <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" onClick={onClose} />
       <motion.div
         initial={{ opacity: 0, scale: 0.95, y: 10 }}

--- a/src/admin/components/DiffModal.tsx
+++ b/src/admin/components/DiffModal.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useMemo, useState } from 'react'
-import { FileSearch, Plus, Trash2, Undo2, X } from 'lucide-react'
-import { motion } from 'framer-motion'
+import { useMemo, useState } from 'react'
+import { FileSearch, Plus, Trash2, Undo2 } from 'lucide-react'
 import { useAdminStore } from '../store'
 import { TABS } from '../config/tabs'
 import { type ChangeEntry, diffTab, groupChangeEntries, type ChangeGroup } from '../lib/diff'
 import { FieldChangeDiff } from './DiffDisplay'
 import type { TabConfig } from '../types'
+import ModalFrame from './ModalFrame'
 
 interface Props {
   tabKey: string
@@ -21,14 +21,6 @@ export default function DiffModal({ tabKey, onClose, onRevertAll }: Props) {
   const revertChange = useAdminStore(s => s.revertChange)
   const [confirmRevertAll, setConfirmRevertAll] = useState(false)
 
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose()
-    }
-    window.addEventListener('keydown', handler)
-    return () => window.removeEventListener('keydown', handler)
-  }, [onClose])
-
   const entries = useMemo(() => {
     if (!tab) return []
     const pendingImagePaths = new Set(pendingUploads.map(u => u.ghPath.replace(/^public/, '')))
@@ -39,95 +31,69 @@ export default function DiffModal({ tabKey, onClose, onRevertAll }: Props) {
 
   if (!tab) return null
 
+  const subtitle = `${entries.length} Änderung${entries.length !== 1 ? 'en' : ''}${entries.length > 0 ? ' · Einzeln oder alle zurücksetzbar' : ''}`
+
   return (
-    <div
-      className="fixed inset-0 z-[9998] bg-black/50 backdrop-blur-sm flex items-center justify-center p-4"
-      onClick={onClose}
+    <ModalFrame
+      onClose={onClose}
+      icon={<FileSearch size={18} className="text-blue-500" />}
+      iconBg="bg-blue-50 dark:bg-blue-900/20"
+      title={`Änderungen — ${tab.label}`}
+      subtitle={subtitle}
     >
-      <motion.div
-        initial={{ opacity: 0, scale: 0.95, y: 10 }}
-        animate={{ opacity: 1, scale: 1, y: 0 }}
-        exit={{ opacity: 0, scale: 0.95, y: 10 }}
-        transition={{ duration: 0.2 }}
-        className="bg-white/95 dark:bg-gray-900/95 backdrop-blur-2xl rounded-3xl p-5 sm:p-7 max-w-lg w-full max-h-[85vh] overflow-y-auto border border-white/50 dark:border-gray-700/50 shadow-2xl"
-        onClick={e => e.stopPropagation()}
-      >
-        <div className="flex items-start justify-between mb-5">
-          <div className="flex items-center gap-3">
-            <div className="w-10 h-10 rounded-xl bg-blue-50 dark:bg-blue-900/20 flex items-center justify-center">
-              <FileSearch size={18} className="text-blue-500" />
-            </div>
-            <div>
-              <h3 className="text-base font-bold dark:text-white">Änderungen — {tab.label}</h3>
-              <p className="text-xs text-gray-400">
-                {entries.length} Änderung{entries.length !== 1 ? 'en' : ''}
-                {entries.length > 0 && ' · Einzeln oder alle zurücksetzbar'}
-              </p>
-            </div>
-          </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 w-8 h-8 rounded-xl hover:bg-gray-100 dark:hover:bg-gray-800 flex items-center justify-center transition-colors"
-          >
-            <X size={16} />
-          </button>
+      {groups.length === 0 ? (
+        <p className="text-sm text-gray-400 text-center py-8">Keine Änderungen gefunden.</p>
+      ) : (
+        <div className="space-y-3">
+          {groups.map(g => (
+            <ChangeGroupBlock key={g.key} group={g} onRevert={e => revertChange(tabKey, e)} />
+          ))}
         </div>
+      )}
 
-        {groups.length === 0 ? (
-          <p className="text-sm text-gray-400 text-center py-8">Keine Änderungen gefunden.</p>
-        ) : (
-          <div className="space-y-3">
-            {groups.map(g => (
-              <ChangeGroupBlock key={g.key} group={g} onRevert={e => revertChange(tabKey, e)} />
-            ))}
-          </div>
-        )}
-
-        <div className="flex items-center justify-between mt-5 gap-2">
-          {entries.length > 0 ? (
-            confirmRevertAll ? (
-              <div className="flex items-center gap-2">
-                <span className="text-xs text-amber-600 dark:text-amber-400 font-medium">
-                  Alle verwerfen?
-                </span>
-                <button
-                  type="button"
-                  className="text-xs px-3 py-2 rounded-xl bg-amber-500 text-white font-semibold hover:bg-amber-600 transition-colors flex items-center gap-1.5"
-                  onClick={onRevertAll}
-                >
-                  <Undo2 size={11} /> Ja, alle verwerfen
-                </button>
-                <button
-                  type="button"
-                  className="text-xs px-3 py-2 rounded-xl border border-gray-200/60 dark:border-gray-700/40 text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-all"
-                  onClick={() => setConfirmRevertAll(false)}
-                >
-                  Abbrechen
-                </button>
-              </div>
-            ) : (
+      <div className="flex items-center justify-between mt-5 gap-2">
+        {entries.length > 0 ? (
+          confirmRevertAll ? (
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-amber-600 dark:text-amber-400 font-medium">
+                Alle verwerfen?
+              </span>
               <button
                 type="button"
-                className="text-xs px-3 py-2 rounded-xl border border-amber-300/60 dark:border-amber-700/40 text-amber-700 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-900/20 transition-colors font-medium flex items-center gap-1.5"
-                onClick={() => setConfirmRevertAll(true)}
+                className="text-xs px-3 py-2 rounded-xl bg-amber-500 text-white font-semibold hover:bg-amber-600 transition-colors flex items-center gap-1.5"
+                onClick={onRevertAll}
               >
-                <Undo2 size={11} /> Alle zurücksetzen
+                <Undo2 size={11} /> Ja, alle verwerfen
               </button>
-            )
+              <button
+                type="button"
+                className="text-xs px-3 py-2 rounded-xl border border-gray-200/60 dark:border-gray-700/40 text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-all"
+                onClick={() => setConfirmRevertAll(false)}
+              >
+                Abbrechen
+              </button>
+            </div>
           ) : (
-            <div />
-          )}
-          <button
-            type="button"
-            className="text-xs px-4 py-2.5 rounded-xl border border-gray-200/60 dark:border-gray-700/40 text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-all"
-            onClick={onClose}
-          >
-            Schließen
-          </button>
-        </div>
-      </motion.div>
-    </div>
+            <button
+              type="button"
+              className="text-xs px-3 py-2 rounded-xl border border-amber-300/60 dark:border-amber-700/40 text-amber-700 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-900/20 transition-colors font-medium flex items-center gap-1.5"
+              onClick={() => setConfirmRevertAll(true)}
+            >
+              <Undo2 size={11} /> Alle zurücksetzen
+            </button>
+          )
+        ) : (
+          <div />
+        )}
+        <button
+          type="button"
+          className="text-xs px-4 py-2.5 rounded-xl border border-gray-200/60 dark:border-gray-700/40 text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-all"
+          onClick={onClose}
+        >
+          Schließen
+        </button>
+      </div>
+    </ModalFrame>
   )
 }
 

--- a/src/admin/components/GlobalDiffModal.tsx
+++ b/src/admin/components/GlobalDiffModal.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useMemo, useState } from 'react'
-import { FileSearch, Undo2, X } from 'lucide-react'
-import { motion } from 'framer-motion'
+import { useMemo, useState } from 'react'
+import { FileSearch, Undo2 } from 'lucide-react'
 import type { TabConfig } from '../types'
 import { useAdminStore } from '../store'
 import { TABS } from '../config/tabs'
 import { type ChangeEntry, diffTab, groupChangeEntries, type ChangeGroup } from '../lib/diff'
 import { FieldChangeDiff } from './DiffDisplay'
+import ModalFrame from './ModalFrame'
 
 interface Props {
   onClose: () => void
@@ -17,8 +17,6 @@ interface TabChanges {
   groups: ChangeGroup[]
 }
 
-// ChangeGroup and groupChangeEntries are imported from lib/diff
-
 export default function GlobalDiffModal({ onClose }: Props) {
   const state = useAdminStore(s => s.state)
   const originalState = useAdminStore(s => s.originalState)
@@ -27,14 +25,6 @@ export default function GlobalDiffModal({ onClose }: Props) {
   const revertTab = useAdminStore(s => s.revertTab)
   const [confirmRevertTab, setConfirmRevertTab] = useState<string | null>(null)
   const [confirmRevertAll, setConfirmRevertAll] = useState(false)
-
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose()
-    }
-    window.addEventListener('keydown', handler)
-    return () => window.removeEventListener('keydown', handler)
-  }, [onClose])
 
   const tabChanges = useMemo<TabChanges[]>(() => {
     const pendingImagePaths = new Set(pendingUploads.map(u => u.ghPath.replace(/^public/, '')))
@@ -56,150 +46,122 @@ export default function GlobalDiffModal({ onClose }: Props) {
 
   const totalChanges = tabChanges.reduce((sum, tc) => sum + tc.entries.length, 0)
 
-  return (
-    <div
-      className="fixed inset-0 z-9998 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4"
-      onClick={onClose}
-    >
-      <motion.div
-        initial={{ opacity: 0, scale: 0.95, y: 10 }}
-        animate={{ opacity: 1, scale: 1, y: 0 }}
-        exit={{ opacity: 0, scale: 0.95, y: 10 }}
-        transition={{ duration: 0.2 }}
-        className="bg-white/95 dark:bg-gray-900/95 backdrop-blur-2xl rounded-3xl p-5 sm:p-7 max-w-lg w-full max-h-[85vh] overflow-y-auto border border-white/50 dark:border-gray-700/50 shadow-2xl"
-        onClick={e => e.stopPropagation()}
-      >
-        <div className="flex items-start justify-between mb-5">
-          <div className="flex items-center gap-3">
-            <div className="w-10 h-10 rounded-xl bg-blue-50 dark:bg-blue-900/20 flex items-center justify-center">
-              <FileSearch size={18} className="text-blue-500" />
-            </div>
-            <div>
-              <h3 className="text-base font-bold dark:text-white">Alle Änderungen</h3>
-              <p className="text-xs text-gray-400">
-                {totalChanges} Änderung{totalChanges !== 1 ? 'en' : ''} in {tabChanges.length} Tab
-                {tabChanges.length !== 1 ? 's' : ''}
-              </p>
-            </div>
-          </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 w-8 h-8 rounded-xl hover:bg-gray-100 dark:hover:bg-gray-800 flex items-center justify-center transition-colors"
-          >
-            <X size={16} />
-          </button>
-        </div>
+  const subtitle = `${totalChanges} Änderung${totalChanges !== 1 ? 'en' : ''} in ${tabChanges.length} Tab${tabChanges.length !== 1 ? 's' : ''}`
 
-        {tabChanges.length === 0 ? (
-          <p className="text-sm text-gray-400 text-center py-8">Keine Änderungen vorhanden.</p>
-        ) : (
-          <div className="space-y-5">
-            {tabChanges.map(tc => (
-              <div key={tc.tab.key}>
-                {/* Tab header */}
-                <div className="flex items-center justify-between mb-2">
-                  <div className="flex items-center gap-2">
-                    <span className="text-xs font-bold text-gray-900 dark:text-white">
-                      {tc.tab.label}
-                    </span>
-                    <span className="text-[10px] font-bold text-gray-400 bg-gray-100 dark:bg-gray-800 px-2 py-0.5 rounded-full">
-                      {tc.entries.length}
-                    </span>
-                  </div>
-                  {confirmRevertTab === tc.tab.key ? (
-                    <div className="flex items-center gap-1.5">
-                      <button
-                        type="button"
-                        className="text-[10px] px-2.5 py-1 rounded-lg bg-amber-500 text-white font-semibold hover:bg-amber-600 transition-colors"
-                        onClick={() => {
-                          revertTab(tc.tab.key)
-                          setConfirmRevertTab(null)
-                        }}
-                      >
-                        Verwerfen
-                      </button>
-                      <button
-                        type="button"
-                        className="text-[10px] px-2.5 py-1 rounded-lg border border-gray-200/60 dark:border-gray-700/40 text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-all"
-                        onClick={() => setConfirmRevertTab(null)}
-                      >
-                        Abbrechen
-                      </button>
-                    </div>
-                  ) : (
+  return (
+    <ModalFrame
+      onClose={onClose}
+      icon={<FileSearch size={18} className="text-blue-500" />}
+      iconBg="bg-blue-50 dark:bg-blue-900/20"
+      title="Alle Änderungen"
+      subtitle={subtitle}
+    >
+      {tabChanges.length === 0 ? (
+        <p className="text-sm text-gray-400 text-center py-8">Keine Änderungen vorhanden.</p>
+      ) : (
+        <div className="space-y-5">
+          {tabChanges.map(tc => (
+            <div key={tc.tab.key}>
+              <div className="flex items-center justify-between mb-2">
+                <div className="flex items-center gap-2">
+                  <span className="text-xs font-bold text-gray-900 dark:text-white">
+                    {tc.tab.label}
+                  </span>
+                  <span className="text-[10px] font-bold text-gray-400 bg-gray-100 dark:bg-gray-800 px-2 py-0.5 rounded-full">
+                    {tc.entries.length}
+                  </span>
+                </div>
+                {confirmRevertTab === tc.tab.key ? (
+                  <div className="flex items-center gap-1.5">
                     <button
                       type="button"
-                      onClick={() => setConfirmRevertTab(tc.tab.key)}
-                      className="text-[10px] font-semibold text-amber-700 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-900/20 px-2.5 py-1 rounded-lg border border-amber-300/60 dark:border-amber-700/40 transition-colors flex items-center gap-1"
+                      className="text-[10px] px-2.5 py-1 rounded-lg bg-amber-500 text-white font-semibold hover:bg-amber-600 transition-colors"
+                      onClick={() => {
+                        revertTab(tc.tab.key)
+                        setConfirmRevertTab(null)
+                      }}
                     >
-                      <Undo2 size={10} /> Tab komplett zurücksetzen
+                      Verwerfen
                     </button>
-                  )}
-                </div>
-                {/* Changes */}
-                <div className="space-y-2">
-                  {tc.groups.map(g => (
-                    <GlobalChangeGroup
-                      key={g.key}
-                      group={g}
-                      tabKey={tc.tab.key}
-                      onRevert={revertChange}
-                    />
-                  ))}
-                </div>
+                    <button
+                      type="button"
+                      className="text-[10px] px-2.5 py-1 rounded-lg border border-gray-200/60 dark:border-gray-700/40 text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-all"
+                      onClick={() => setConfirmRevertTab(null)}
+                    >
+                      Abbrechen
+                    </button>
+                  </div>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => setConfirmRevertTab(tc.tab.key)}
+                    className="text-[10px] font-semibold text-amber-700 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-900/20 px-2.5 py-1 rounded-lg border border-amber-300/60 dark:border-amber-700/40 transition-colors flex items-center gap-1"
+                  >
+                    <Undo2 size={10} /> Tab komplett zurücksetzen
+                  </button>
+                )}
               </div>
-            ))}
-          </div>
-        )}
+              <div className="space-y-2">
+                {tc.groups.map(g => (
+                  <GlobalChangeGroup
+                    key={g.key}
+                    group={g}
+                    tabKey={tc.tab.key}
+                    onRevert={revertChange}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
 
-        <div className="flex items-center justify-between mt-5 gap-2">
-          {tabChanges.length > 0 ? (
-            confirmRevertAll ? (
-              <div className="flex items-center gap-2">
-                <span className="text-xs text-amber-600 dark:text-amber-400 font-medium">
-                  Alles verwerfen?
-                </span>
-                <button
-                  type="button"
-                  className="text-xs px-3 py-2 rounded-xl bg-amber-500 text-white font-semibold hover:bg-amber-600 transition-colors flex items-center gap-1.5"
-                  onClick={() => {
-                    for (const tc of tabChanges) revertTab(tc.tab.key)
-                    setConfirmRevertAll(false)
-                  }}
-                >
-                  <Undo2 size={11} /> Ja, alles verwerfen
-                </button>
-                <button
-                  type="button"
-                  className="text-xs px-3 py-2 rounded-xl border border-gray-200/60 dark:border-gray-700/40 text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-all"
-                  onClick={() => setConfirmRevertAll(false)}
-                >
-                  Abbrechen
-                </button>
-              </div>
-            ) : (
+      <div className="flex items-center justify-between mt-5 gap-2">
+        {tabChanges.length > 0 ? (
+          confirmRevertAll ? (
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-amber-600 dark:text-amber-400 font-medium">
+                Alles verwerfen?
+              </span>
               <button
                 type="button"
-                className="text-xs font-semibold px-3 py-2 rounded-xl text-amber-700 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-900/20 border border-amber-300/60 dark:border-amber-700/40 transition-colors flex items-center gap-1.5"
-                onClick={() => setConfirmRevertAll(true)}
+                className="text-xs px-3 py-2 rounded-xl bg-amber-500 text-white font-semibold hover:bg-amber-600 transition-colors flex items-center gap-1.5"
+                onClick={() => {
+                  for (const tc of tabChanges) revertTab(tc.tab.key)
+                  setConfirmRevertAll(false)
+                }}
               >
-                <Undo2 size={11} /> Alle zurücksetzen
+                <Undo2 size={11} /> Ja, alles verwerfen
               </button>
-            )
+              <button
+                type="button"
+                className="text-xs px-3 py-2 rounded-xl border border-gray-200/60 dark:border-gray-700/40 text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-all"
+                onClick={() => setConfirmRevertAll(false)}
+              >
+                Abbrechen
+              </button>
+            </div>
           ) : (
-            <div />
-          )}
-          <button
-            type="button"
-            className="text-xs px-4 py-2.5 rounded-xl border border-gray-200/60 dark:border-gray-700/40 text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-all"
-            onClick={onClose}
-          >
-            Schließen
-          </button>
-        </div>
-      </motion.div>
-    </div>
+            <button
+              type="button"
+              className="text-xs font-semibold px-3 py-2 rounded-xl text-amber-700 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-900/20 border border-amber-300/60 dark:border-amber-700/40 transition-colors flex items-center gap-1.5"
+              onClick={() => setConfirmRevertAll(true)}
+            >
+              <Undo2 size={11} /> Alle zurücksetzen
+            </button>
+          )
+        ) : (
+          <div />
+        )}
+        <button
+          type="button"
+          className="text-xs px-4 py-2.5 rounded-xl border border-gray-200/60 dark:border-gray-700/40 text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-all"
+          onClick={onClose}
+        >
+          Schließen
+        </button>
+      </div>
+    </ModalFrame>
   )
 }
 

--- a/src/admin/components/HaushaltsredenEditor.tsx
+++ b/src/admin/components/HaushaltsredenEditor.tsx
@@ -64,7 +64,7 @@ export default function HaushaltsredenEditor() {
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
-            className="fixed inset-0 z-50 bg-black/40 backdrop-blur-sm flex items-center justify-center p-4"
+            className="fixed inset-0 z-[9999] bg-black/40 backdrop-blur-sm flex items-center justify-center p-4"
           >
             <motion.div
               initial={{ opacity: 0, scale: 0.95, y: 10 }}

--- a/src/admin/components/KommunalpolitikEditor.tsx
+++ b/src/admin/components/KommunalpolitikEditor.tsx
@@ -13,13 +13,7 @@ import {
 import { AnimatePresence, motion } from 'framer-motion'
 import { useAdminStore } from '../store'
 import ArrayEditor from './ArrayEditor'
-import DiffModal from './DiffModal'
-import OrphanModal from './OrphanModal'
-import PreviewModal from './PreviewModal'
-import PublishConfirmModal from './PublishConfirmModal'
-import StickyPublishBar from './StickyPublishBar'
-import AdminActionBar from './AdminActionBar'
-import AdminWarningBanner from './AdminWarningBanner'
+import TabEditorShell from './TabEditorShell'
 import { CollapsibleSectionHeader } from './CollapsibleSection'
 import { fileToBase64 } from '../lib/images'
 import { openPendingFile } from '../lib/fileUtils'
@@ -56,64 +50,18 @@ export default function KommunalpolitikEditor() {
   const loadData = useAdminStore(s => s.loadData)
 
   return (
-    <div className="pb-28">
-      {publisher.orphans && (
-        <OrphanModal
-          orphans={publisher.orphans}
-          onConfirm={publisher.handleOrphanConfirm}
-          onKeep={publisher.handleOrphanKeep}
-          onCancel={publisher.handleOrphanCancel}
-        />
-      )}
-      {publisher.showPreview && (
-        <PreviewModal tabKey="kommunalpolitik" onClose={() => publisher.setShowPreview(false)} />
-      )}
-      {publisher.showPublishConfirm && (
-        <PublishConfirmModal
-          tabKey="kommunalpolitik"
-          onConfirm={publisher.handlePublishConfirmed}
-          onCancel={() => publisher.setShowPublishConfirm(false)}
-        />
-      )}
-      {publisher.showDiff && (
-        <DiffModal
-          tabKey="kommunalpolitik"
-          onClose={() => publisher.setShowDiff(false)}
-          onRevertAll={publisher.handleRevertAndCloseDiff}
-        />
-      )}
-
-      {/* Load-error banner */}
-      {hasLoadError && (
-        <div className="mb-5">
-          <AdminWarningBanner>
-            Daten für diesen Tab konnten nicht geladen werden. Veröffentlichen ist gesperrt —{' '}
-            <button
-              type="button"
-              onClick={loadData}
-              className="underline font-semibold hover:no-underline"
-            >
-              Erneut versuchen
-            </button>
-          </AdminWarningBanner>
-        </div>
-      )}
-
-      {/* Unified action bar */}
-      <AdminActionBar
-        isDirty={isDirty}
-        publishing={publisher.publishing}
-        hasLoadError={hasLoadError}
-        canUndo={canUndo}
-        canRedo={canRedo}
-        previewPath="/kommunalpolitik"
-        onUndo={undo}
-        onRedo={redo}
-        onShowPreview={() => publisher.setShowPreview(true)}
-        onShowDiff={() => publisher.setShowDiff(true)}
-        onDownload={publisher.handleDownload}
-        onPublish={publisher.handlePublish}
-      />
+    <TabEditorShell
+      tabKey="kommunalpolitik"
+      previewPath="/kommunalpolitik"
+      isDirty={isDirty}
+      hasLoadError={hasLoadError}
+      canUndo={canUndo}
+      canRedo={canRedo}
+      publisher={publisher}
+      onUndo={undo}
+      onRedo={redo}
+      onReloadData={loadData}
+    >
 
       {/* Sichtbar toggle */}
       <div className="bg-white/60 dark:bg-gray-900/40 backdrop-blur-sm border border-gray-200/50 dark:border-gray-700/40 rounded-2xl p-5 mb-6">
@@ -395,13 +343,7 @@ export default function KommunalpolitikEditor() {
         </AnimatePresence>
       </div>
 
-      <StickyPublishBar
-        isDirty={isDirty && !hasLoadError}
-        publishing={publisher.publishing}
-        onPublish={publisher.handlePublish}
-        onShowDiff={() => publisher.setShowDiff(true)}
-      />
-    </div>
+    </TabEditorShell>
   )
 }
 

--- a/src/admin/components/ModalFrame.tsx
+++ b/src/admin/components/ModalFrame.tsx
@@ -1,0 +1,58 @@
+import { type ReactNode, useEffect } from 'react'
+import { X } from 'lucide-react'
+import { motion } from 'framer-motion'
+
+interface ModalFrameProps {
+  onClose: () => void
+  icon: ReactNode
+  iconBg: string
+  title: string
+  subtitle?: ReactNode
+  children: ReactNode
+}
+
+export default function ModalFrame({ onClose, icon, iconBg, title, subtitle, children }: ModalFrameProps) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [onClose])
+
+  return (
+    <div
+      className="fixed inset-0 z-[9999] bg-black/50 backdrop-blur-sm flex items-center justify-center p-4"
+      onClick={onClose}
+    >
+      <motion.div
+        initial={{ opacity: 0, scale: 0.95, y: 10 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        exit={{ opacity: 0, scale: 0.95, y: 10 }}
+        transition={{ duration: 0.2 }}
+        className="bg-white/95 dark:bg-gray-900/95 backdrop-blur-2xl rounded-3xl p-5 sm:p-7 max-w-lg w-full max-h-[85vh] overflow-y-auto border border-white/50 dark:border-gray-700/50 shadow-2xl"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between mb-5">
+          <div className="flex items-center gap-3">
+            <div className={`w-10 h-10 rounded-xl ${iconBg} flex items-center justify-center`}>
+              {icon}
+            </div>
+            <div>
+              <h3 className="text-base font-bold dark:text-white">{title}</h3>
+              {subtitle && <p className="text-xs text-gray-400">{subtitle}</p>}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 w-8 h-8 rounded-xl hover:bg-gray-100 dark:hover:bg-gray-800 flex items-center justify-center transition-colors"
+          >
+            <X size={16} />
+          </button>
+        </div>
+        {children}
+      </motion.div>
+    </div>
+  )
+}

--- a/src/admin/components/OrphanModal.tsx
+++ b/src/admin/components/OrphanModal.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react'
-import { ImageOff, Trash2, X } from 'lucide-react'
-import { motion } from 'framer-motion'
+import { useState } from 'react'
+import { ImageOff, Trash2 } from 'lucide-react'
+import ModalFrame from './ModalFrame'
 
 interface Props {
   orphans: string[]
@@ -14,93 +14,58 @@ export default function OrphanModal({ orphans, onConfirm, onKeep, onCancel }: Pr
     Object.fromEntries(orphans.map(o => [o, true])),
   )
 
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onCancel()
-    }
-    window.addEventListener('keydown', handler)
-    return () => window.removeEventListener('keydown', handler)
-  }, [onCancel])
-
   return (
-    <div
-      className="fixed inset-0 z-[9998] bg-black/50 backdrop-blur-sm flex items-center justify-center p-4"
-      onClick={onCancel}
+    <ModalFrame
+      onClose={onCancel}
+      icon={<ImageOff size={18} className="text-red-500" />}
+      iconBg="bg-red-50 dark:bg-red-900/20"
+      title="Nicht verwendete Bilder"
+      subtitle={`${orphans.length} Bild${orphans.length !== 1 ? 'er' : ''} gefunden`}
     >
-      <motion.div
-        initial={{ opacity: 0, scale: 0.95, y: 10 }}
-        animate={{ opacity: 1, scale: 1, y: 0 }}
-        exit={{ opacity: 0, scale: 0.95, y: 10 }}
-        transition={{ duration: 0.2 }}
-        className="bg-white/90 dark:bg-gray-900/90 backdrop-blur-2xl rounded-3xl p-6 sm:p-8 max-w-md w-full max-h-[80vh] overflow-y-auto border border-white/50 dark:border-gray-700/50 shadow-2xl"
-        onClick={e => e.stopPropagation()}
-      >
-        <div className="flex items-start justify-between mb-5">
-          <div className="flex items-center gap-3">
-            <div className="w-10 h-10 rounded-xl bg-red-50 dark:bg-red-900/20 flex items-center justify-center">
-              <ImageOff size={18} className="text-red-500" />
-            </div>
-            <div>
-              <h3 className="text-base font-bold dark:text-white">Nicht verwendete Bilder</h3>
-              <p className="text-xs text-gray-400">
-                {orphans.length} Bild{orphans.length !== 1 ? 'er' : ''} gefunden
-              </p>
-            </div>
-          </div>
-          <button
-            type="button"
-            onClick={onCancel}
-            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 w-8 h-8 rounded-xl hover:bg-gray-100 dark:hover:bg-gray-800 flex items-center justify-center transition-colors"
-          >
-            <X size={16} />
-          </button>
-        </div>
+      <p className="text-sm text-gray-500 dark:text-gray-400 mb-5 leading-relaxed">
+        Diese Bilder werden nicht mehr referenziert. Möchten Sie sie vom Server löschen?
+      </p>
 
-        <p className="text-sm text-gray-500 dark:text-gray-400 mb-5 leading-relaxed">
-          Diese Bilder werden nicht mehr referenziert. Möchten Sie sie vom Server löschen?
-        </p>
+      <div className="space-y-1.5 mb-6">
+        {orphans.map(path => (
+          <label
+            key={path}
+            className="flex items-center gap-3 py-2 px-3 text-sm text-gray-700 dark:text-gray-300 cursor-pointer hover:bg-gray-50/80 dark:hover:bg-gray-800/40 rounded-xl -mx-1 transition-colors"
+          >
+            <input
+              type="checkbox"
+              checked={checked[path]}
+              onChange={e => setChecked(prev => ({ ...prev, [path]: e.target.checked }))}
+              className="accent-spd-red rounded w-4 h-4"
+            />
+            <span className="truncate text-xs font-mono text-gray-500">{path}</span>
+          </label>
+        ))}
+      </div>
 
-        <div className="space-y-1.5 mb-6">
-          {orphans.map(path => (
-            <label
-              key={path}
-              className="flex items-center gap-3 py-2 px-3 text-sm text-gray-700 dark:text-gray-300 cursor-pointer hover:bg-gray-50/80 dark:hover:bg-gray-800/40 rounded-xl -mx-1 transition-colors"
-            >
-              <input
-                type="checkbox"
-                checked={checked[path]}
-                onChange={e => setChecked(prev => ({ ...prev, [path]: e.target.checked }))}
-                className="accent-spd-red rounded w-4 h-4"
-              />
-              <span className="truncate text-xs font-mono text-gray-500">{path}</span>
-            </label>
-          ))}
-        </div>
-
-        <div className="flex gap-2 justify-end flex-wrap">
-          <button
-            type="button"
-            className="text-xs px-4 py-2.5 rounded-xl border border-gray-200/60 dark:border-gray-700/40 text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-all hover:bg-gray-50 dark:hover:bg-gray-800/40"
-            onClick={onKeep}
-          >
-            Behalten
-          </button>
-          <button
-            type="button"
-            className="text-xs px-4 py-2.5 rounded-xl bg-gradient-to-r from-red-500 to-red-600 text-white font-semibold hover:shadow-lg hover:shadow-red-500/25 transition-all flex items-center gap-1.5"
-            onClick={() => onConfirm(orphans.filter(p => checked[p]))}
-          >
-            <Trash2 size={12} /> Löschen
-          </button>
-          <button
-            type="button"
-            className="text-xs px-4 py-2.5 rounded-xl border border-gray-200/60 dark:border-gray-700/40 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-all"
-            onClick={onCancel}
-          >
-            Abbrechen
-          </button>
-        </div>
-      </motion.div>
-    </div>
+      <div className="flex gap-2 justify-end flex-wrap">
+        <button
+          type="button"
+          className="text-xs px-4 py-2.5 rounded-xl border border-gray-200/60 dark:border-gray-700/40 text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-all hover:bg-gray-50 dark:hover:bg-gray-800/40"
+          onClick={onKeep}
+        >
+          Behalten
+        </button>
+        <button
+          type="button"
+          className="text-xs px-4 py-2.5 rounded-xl bg-gradient-to-r from-red-500 to-red-600 text-white font-semibold hover:shadow-lg hover:shadow-red-500/25 transition-all flex items-center gap-1.5"
+          onClick={() => onConfirm(orphans.filter(p => checked[p]))}
+        >
+          <Trash2 size={12} /> Löschen
+        </button>
+        <button
+          type="button"
+          className="text-xs px-4 py-2.5 rounded-xl border border-gray-200/60 dark:border-gray-700/40 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-all"
+          onClick={onCancel}
+        >
+          Abbrechen
+        </button>
+      </div>
+    </ModalFrame>
   )
 }

--- a/src/admin/components/PreviewModal.tsx
+++ b/src/admin/components/PreviewModal.tsx
@@ -99,7 +99,7 @@ export default function PreviewModal({ tabKey, onClose }: Props) {
 
   return (
     <div
-      className="fixed inset-0 z-9999 flex flex-col bg-black/60 backdrop-blur-sm"
+      className="fixed inset-0 z-[9999] flex flex-col bg-black/60 backdrop-blur-sm"
       onClick={onClose}
     >
       <motion.div

--- a/src/admin/components/PublishConfirmModal.tsx
+++ b/src/admin/components/PublishConfirmModal.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useMemo } from 'react'
-import { Loader2, Rocket, Undo2, X } from 'lucide-react'
-import { motion } from 'framer-motion'
+import { useMemo } from 'react'
+import { Loader2, Rocket, Undo2 } from 'lucide-react'
 import type { TabConfig } from '../types'
 import { useAdminStore } from '../store'
 import { TABS } from '../config/tabs'
 import { diffTab, type ChangeEntry, groupChangeEntries, type ChangeGroup } from '../lib/diff'
 import { FieldChangeDiff } from './DiffDisplay'
+import ModalFrame from './ModalFrame'
 
 interface Props {
   tabKey?: string
@@ -13,22 +13,12 @@ interface Props {
   onCancel: () => void
 }
 
-// ChangeGroup and groupChangeEntries are imported from lib/diff
-
 export default function PublishConfirmModal({ tabKey, onConfirm, onCancel }: Props) {
   const state = useAdminStore(s => s.state)
   const originalState = useAdminStore(s => s.originalState)
   const pendingUploads = useAdminStore(s => s.pendingUploads)
   const publishing = useAdminStore(s => s.publishing)
   const revertChange = useAdminStore(s => s.revertChange)
-
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onCancel()
-    }
-    window.addEventListener('keydown', handler)
-    return () => window.removeEventListener('keydown', handler)
-  }, [onCancel])
 
   const tabChanges = useMemo(() => {
     const pendingImagePaths = new Set(pendingUploads.map(u => u.ghPath.replace(/^public/, '')))
@@ -51,101 +41,72 @@ export default function PublishConfirmModal({ tabKey, onConfirm, onCancel }: Pro
 
   const totalChanges = tabChanges.reduce((sum, tc) => sum + tc.entries.length, 0)
 
+  const subtitle = `${totalChanges} Änderung${totalChanges !== 1 ? 'en' : ''} in ${tabChanges.length} Tab${tabChanges.length !== 1 ? 's' : ''}`
+
   return (
-    <div
-      className="fixed inset-0 z-9999 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4"
-      onClick={onCancel}
+    <ModalFrame
+      onClose={onCancel}
+      icon={<Rocket size={18} className="text-spd-red" />}
+      iconBg="bg-spd-red/10 dark:bg-spd-red/20"
+      title="Veröffentlichen bestätigen"
+      subtitle={subtitle}
     >
-      <motion.div
-        initial={{ opacity: 0, scale: 0.95, y: 10 }}
-        animate={{ opacity: 1, scale: 1, y: 0 }}
-        exit={{ opacity: 0, scale: 0.95, y: 10 }}
-        transition={{ duration: 0.2 }}
-        className="bg-white/95 dark:bg-gray-900/95 backdrop-blur-2xl rounded-3xl p-5 sm:p-7 max-w-lg w-full max-h-[85vh] overflow-y-auto border border-white/50 dark:border-gray-700/50 shadow-2xl"
-        onClick={e => e.stopPropagation()}
-      >
-        {/* Header */}
-        <div className="flex items-start justify-between mb-5">
-          <div className="flex items-center gap-3">
-            <div className="w-10 h-10 rounded-xl bg-spd-red/10 dark:bg-spd-red/20 flex items-center justify-center">
-              <Rocket size={18} className="text-spd-red" />
-            </div>
-            <div>
-              <h3 className="text-base font-bold dark:text-white">Veröffentlichen bestätigen</h3>
-              <p className="text-xs text-gray-400">
-                {totalChanges} Änderung{totalChanges !== 1 ? 'en' : ''} in {tabChanges.length} Tab
-                {tabChanges.length !== 1 ? 's' : ''}
-              </p>
-            </div>
-          </div>
-          <button
-            type="button"
-            onClick={onCancel}
-            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 w-8 h-8 rounded-xl hover:bg-gray-100 dark:hover:bg-gray-800 flex items-center justify-center transition-colors"
-          >
-            <X size={16} />
-          </button>
-        </div>
-
-        {/* Changes preview */}
-        <div className="space-y-5 mb-6">
-          {tabChanges.length === 0 ? (
-            <p className="text-sm text-gray-400 text-center py-4">
-              Keine Änderungen mehr vorhanden.
-            </p>
-          ) : (
-            tabChanges.map(tc => (
-              <div key={tc.tab.key}>
-                <div className="flex items-center gap-2 mb-2">
-                  <span className="text-xs font-bold text-gray-900 dark:text-white">
-                    {tc.tab.label}
-                  </span>
-                  <span className="text-[10px] font-bold text-gray-400 bg-gray-100 dark:bg-gray-800 px-2 py-0.5 rounded-full">
-                    {tc.entries.length}
-                  </span>
-                </div>
-                <div className="space-y-2">
-                  {tc.groups.map(g => (
-                    <PublishChangeGroup
-                      key={g.key}
-                      group={g}
-                      tabKey={tc.tab.key}
-                      onRevert={revertChange}
-                    />
-                  ))}
-                </div>
+      <div className="space-y-5 mb-6">
+        {tabChanges.length === 0 ? (
+          <p className="text-sm text-gray-400 text-center py-4">
+            Keine Änderungen mehr vorhanden.
+          </p>
+        ) : (
+          tabChanges.map(tc => (
+            <div key={tc.tab.key}>
+              <div className="flex items-center gap-2 mb-2">
+                <span className="text-xs font-bold text-gray-900 dark:text-white">
+                  {tc.tab.label}
+                </span>
+                <span className="text-[10px] font-bold text-gray-400 bg-gray-100 dark:bg-gray-800 px-2 py-0.5 rounded-full">
+                  {tc.entries.length}
+                </span>
               </div>
-            ))
-          )}
-        </div>
+              <div className="space-y-2">
+                {tc.groups.map(g => (
+                  <PublishChangeGroup
+                    key={g.key}
+                    group={g}
+                    tabKey={tc.tab.key}
+                    onRevert={revertChange}
+                  />
+                ))}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
 
-        {/* Actions */}
-        <div className="flex items-center justify-end gap-2">
-          <button
-            type="button"
-            className="text-xs px-4 py-2.5 rounded-xl border border-gray-200/60 dark:border-gray-700/40 text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-all"
-            onClick={onCancel}
-          >
-            Abbrechen
-          </button>
-          <button
-            type="button"
-            className="text-xs px-4 py-2.5 rounded-xl bg-spd-red hover:bg-spd-red-dark text-white font-bold shadow-sm shadow-spd-red/25 hover:shadow-lg hover:shadow-spd-red/35 active:scale-[0.98] transition-colors flex items-center gap-2 disabled:cursor-wait disabled:hover:bg-spd-red disabled:active:scale-100 whitespace-nowrap [hyphens:none]"
-            onClick={onConfirm}
-            disabled={publishing || totalChanges === 0}
-          >
-            {publishing ? (
-              <Loader2 size={14} strokeWidth={2.5} className="animate-spin shrink-0" />
-            ) : (
-              <Rocket size={14} strokeWidth={2.5} className="shrink-0" />
-            )}
-            <span className="whitespace-nowrap">
-              {publishing ? 'Veröffentliche…' : 'Ja, veröffentlichen'}
-            </span>
-          </button>
-        </div>
-      </motion.div>
-    </div>
+      <div className="flex items-center justify-end gap-2">
+        <button
+          type="button"
+          className="text-xs px-4 py-2.5 rounded-xl border border-gray-200/60 dark:border-gray-700/40 text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-all"
+          onClick={onCancel}
+        >
+          Abbrechen
+        </button>
+        <button
+          type="button"
+          className="text-xs px-4 py-2.5 rounded-xl bg-spd-red hover:bg-spd-red-dark text-white font-bold shadow-sm shadow-spd-red/25 hover:shadow-lg hover:shadow-spd-red/35 active:scale-[0.98] transition-colors flex items-center gap-2 disabled:cursor-wait disabled:hover:bg-spd-red disabled:active:scale-100 whitespace-nowrap [hyphens:none]"
+          onClick={onConfirm}
+          disabled={publishing || totalChanges === 0}
+        >
+          {publishing ? (
+            <Loader2 size={14} strokeWidth={2.5} className="animate-spin shrink-0" />
+          ) : (
+            <Rocket size={14} strokeWidth={2.5} className="shrink-0" />
+          )}
+          <span className="whitespace-nowrap">
+            {publishing ? 'Veröffentliche…' : 'Ja, veröffentlichen'}
+          </span>
+        </button>
+      </div>
+    </ModalFrame>
   )
 }
 

--- a/src/admin/components/TabEditor.tsx
+++ b/src/admin/components/TabEditor.tsx
@@ -2,15 +2,9 @@ import type { SectionConfig, TabConfig } from '../types'
 import { useAdminStore } from '../store'
 import FieldRenderer from './FieldRenderer'
 import ArrayEditor from './ArrayEditor'
-import OrphanModal from './OrphanModal'
-import PreviewModal from './PreviewModal'
-import PublishConfirmModal from './PublishConfirmModal'
-import StickyPublishBar from './StickyPublishBar'
-import DiffModal from './DiffModal'
-import AdminActionBar from './AdminActionBar'
 import HaushaltsredenEditor from './HaushaltsredenEditor'
 import KommunalpolitikEditor from './KommunalpolitikEditor'
-import AdminWarningBanner from './AdminWarningBanner'
+import TabEditorShell from './TabEditorShell'
 import { CollapsibleSection, CollapsibleSectionHeader } from './CollapsibleSection'
 import { useUndoRedoShortcuts } from '../hooks/useUndoRedoShortcuts'
 import { useTabPublisher } from '../hooks/useTabPublisher'
@@ -33,102 +27,37 @@ export default function TabEditor({ tab }: Props) {
 // ─── Generic editor (array / object tabs) ─────────────────────────────────────
 
 function GenericTabEditor({ tab }: Props) {
-  const state = useAdminStore(s => s.state)
   const undo = useAdminStore(s => s.undo)
   const redo = useAdminStore(s => s.redo)
   const undoStacks = useAdminStore(s => s.undoStacks)
   const redoStacks = useAdminStore(s => s.redoStacks)
   const loadData = useAdminStore(s => s.loadData)
-  // Block publishing for this tab if its data failed to load on startup
   const hasLoadError = useAdminStore(s => s.dataLoadErrors.includes(tab.key))
+  const isDirty = useAdminStore(s => s.dirtyTabs().has(tab.key))
+  const data = useAdminStore(s => s.state[tab.key])
 
   const canUndo = (undoStacks[tab.key]?.length ?? 0) > 0
   const canRedo = (redoStacks[tab.key]?.length ?? 0) > 0
 
-  // Keyboard shortcuts for undo/redo
   useUndoRedoShortcuts(tab.key, undo, redo)
 
-  const data = state[tab.key]
-
-  // Must be called before any conditional return to satisfy Rules of Hooks.
-  // Zustand compares the boolean result — component only re-renders when the
-  // dirty flag for this specific tab actually changes.
-  const isDirty = useAdminStore(s => s.dirtyTabs().has(tab.key))
-
-  const filename = tab.file?.split('/').pop()
-  const publisher = useTabPublisher(tab.key, filename)
+  const publisher = useTabPublisher(tab.key, tab.file?.split('/').pop())
 
   if (!data) return <p className="text-gray-400 text-center py-20">Daten werden geladen…</p>
 
   return (
-    <div>
-      {publisher.orphans && (
-        <OrphanModal
-          orphans={publisher.orphans}
-          onConfirm={publisher.handleOrphanConfirm}
-          onKeep={publisher.handleOrphanKeep}
-          onCancel={publisher.handleOrphanCancel}
-        />
-      )}
-
-      {publisher.showPublishConfirm && (
-        <PublishConfirmModal
-          tabKey={tab.key}
-          onConfirm={publisher.handlePublishConfirmed}
-          onCancel={() => publisher.setShowPublishConfirm(false)}
-        />
-      )}
-
-      {publisher.showDiff && (
-        <DiffModal
-          tabKey={tab.key}
-          onClose={() => publisher.setShowDiff(false)}
-          onRevertAll={publisher.handleRevertAndCloseDiff}
-        />
-      )}
-
-      {publisher.showPreview && (
-        <PreviewModal tabKey={tab.key} onClose={() => publisher.setShowPreview(false)} />
-      )}
-
-      {/* Load-error warning — shown inline so it's visible next to the publish button */}
-      {hasLoadError && (
-        <div className="mb-5">
-          <AdminWarningBanner>
-            Daten für diesen Tab konnten nicht geladen werden. Veröffentlichen ist gesperrt —{' '}
-            <button
-              type="button"
-              onClick={loadData}
-              className="underline font-semibold hover:no-underline"
-            >
-              Erneut versuchen
-            </button>
-          </AdminWarningBanner>
-        </div>
-      )}
-
-      <AdminActionBar
-        isDirty={isDirty}
-        publishing={publisher.publishing}
-        hasLoadError={hasLoadError}
-        canUndo={canUndo}
-        canRedo={canRedo}
-        previewPath={tab.previewPath}
-        onUndo={() => undo(tab.key)}
-        onRedo={() => redo(tab.key)}
-        onShowPreview={() => publisher.setShowPreview(true)}
-        onShowDiff={() => publisher.setShowDiff(true)}
-        onDownload={publisher.handleDownload}
-        onPublish={publisher.handlePublish}
-      />
-
-      <StickyPublishBar
-        isDirty={isDirty && !hasLoadError}
-        publishing={publisher.publishing}
-        onPublish={publisher.handlePublish}
-        onShowDiff={() => publisher.setShowDiff(true)}
-      />
-
+    <TabEditorShell
+      tabKey={tab.key}
+      previewPath={tab.previewPath}
+      isDirty={isDirty}
+      hasLoadError={hasLoadError}
+      canUndo={canUndo}
+      canRedo={canRedo}
+      publisher={publisher}
+      onUndo={() => undo(tab.key)}
+      onRedo={() => redo(tab.key)}
+      onReloadData={loadData}
+    >
       {tab.type === 'array' && tab.fields && (
         <ArrayEditor
           fields={tab.fields}
@@ -136,9 +65,8 @@ function GenericTabEditor({ tab }: Props) {
           tabKey={tab.key}
         />
       )}
-
       {tab.type === 'object' && <ObjectEditor tab={tab} data={data as Record<string, unknown>} />}
-    </div>
+    </TabEditorShell>
   )
 }
 

--- a/src/admin/components/TabEditorShell.tsx
+++ b/src/admin/components/TabEditorShell.tsx
@@ -1,0 +1,108 @@
+import type { ReactNode } from 'react'
+import type { useTabPublisher } from '../hooks/useTabPublisher'
+import AdminActionBar from './AdminActionBar'
+import StickyPublishBar from './StickyPublishBar'
+import AdminWarningBanner from './AdminWarningBanner'
+import OrphanModal from './OrphanModal'
+import PreviewModal from './PreviewModal'
+import PublishConfirmModal from './PublishConfirmModal'
+import DiffModal from './DiffModal'
+
+type Publisher = ReturnType<typeof useTabPublisher>
+
+interface TabEditorShellProps {
+  tabKey: string
+  previewPath?: string
+  isDirty: boolean
+  hasLoadError: boolean
+  canUndo: boolean
+  canRedo: boolean
+  publisher: Publisher
+  onUndo: () => void
+  onRedo: () => void
+  onReloadData: () => void
+  children: ReactNode
+}
+
+export default function TabEditorShell({
+  tabKey,
+  previewPath,
+  isDirty,
+  hasLoadError,
+  canUndo,
+  canRedo,
+  publisher,
+  onUndo,
+  onRedo,
+  onReloadData,
+  children,
+}: TabEditorShellProps) {
+  return (
+    <div className="pb-28">
+      {publisher.orphans && (
+        <OrphanModal
+          orphans={publisher.orphans}
+          onConfirm={publisher.handleOrphanConfirm}
+          onKeep={publisher.handleOrphanKeep}
+          onCancel={publisher.handleOrphanCancel}
+        />
+      )}
+      {publisher.showPublishConfirm && (
+        <PublishConfirmModal
+          tabKey={tabKey}
+          onConfirm={publisher.handlePublishConfirmed}
+          onCancel={() => publisher.setShowPublishConfirm(false)}
+        />
+      )}
+      {publisher.showDiff && (
+        <DiffModal
+          tabKey={tabKey}
+          onClose={() => publisher.setShowDiff(false)}
+          onRevertAll={publisher.handleRevertAndCloseDiff}
+        />
+      )}
+      {publisher.showPreview && (
+        <PreviewModal tabKey={tabKey} onClose={() => publisher.setShowPreview(false)} />
+      )}
+
+      {hasLoadError && (
+        <div className="mb-5">
+          <AdminWarningBanner>
+            Daten für diesen Tab konnten nicht geladen werden. Veröffentlichen ist gesperrt —{' '}
+            <button
+              type="button"
+              onClick={onReloadData}
+              className="underline font-semibold hover:no-underline"
+            >
+              Erneut versuchen
+            </button>
+          </AdminWarningBanner>
+        </div>
+      )}
+
+      <AdminActionBar
+        isDirty={isDirty}
+        publishing={publisher.publishing}
+        hasLoadError={hasLoadError}
+        canUndo={canUndo}
+        canRedo={canRedo}
+        previewPath={previewPath}
+        onUndo={onUndo}
+        onRedo={onRedo}
+        onShowPreview={() => publisher.setShowPreview(true)}
+        onShowDiff={() => publisher.setShowDiff(true)}
+        onDownload={publisher.handleDownload}
+        onPublish={publisher.handlePublish}
+      />
+
+      <StickyPublishBar
+        isDirty={isDirty && !hasLoadError}
+        publishing={publisher.publishing}
+        onPublish={publisher.handlePublish}
+        onShowDiff={() => publisher.setShowDiff(true)}
+      />
+
+      {children}
+    </div>
+  )
+}


### PR DESCRIPTION
Three targeted simplifications identified during a code audit:

- **ModalFrame**: shared wrapper for modal backdrop, animation, Escape key, and header. Applied to DiffModal, GlobalDiffModal, PublishConfirmModal, OrphanModal — ~20 lines removed per modal.
- **TabEditorShell**: shared wrapper for modal stack + AdminActionBar + StickyPublishBar. GenericTabEditor and KommunalpolitikEditor both use it — ~50 lines removed from KommunalpolitikEditor.
- **z-index**: standardised all modal backdrops to `z-[9999]`. Previously used z-50, z-9998, z-[9998], and z-9999 across 7 files.

Net: −110 lines, 2 new shared components.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFYvCGhi5ecA78zygDFhgP)_