### PR TITLE
refactor: extract useSheetState hook and shared PersonGrid component

### DIFF
--- a/src/components/PersonGrid.tsx
+++ b/src/components/PersonGrid.tsx
@@ -1,25 +1,38 @@
 import { motion } from 'framer-motion'
-import { personCardContainerVariants } from '@/components/personCardVariants'
-import PersonCard from '@/components/PersonCard'
-import { SkeletonGrid } from '@/components/SkeletonGrid'
-import type { Gemeinderat } from './types'
+import { personCardContainerVariants } from './personCardVariants'
+import PersonCard from './PersonCard'
+import { SkeletonGrid } from './SkeletonGrid'
 
-export function PersonGrid({
+interface PersonBase {
+  name: string
+  bildUrl?: string
+}
+
+interface PersonGridProps<T extends PersonBase> {
+  label: string
+  countLabel?: string
+  /** undefined = still loading (shows skeleton); empty array = no members (hidden) */
+  members: T[] | undefined
+  isInView: boolean
+  animationDelay: number
+  onSelect: (m: T, i: number) => void
+  /** Extra PersonCard props per member. Use for label, sublabel, priority, etc. */
+  renderCardProps?: (member: T, index: number) => { label?: string; sublabel?: string; priority?: boolean }
+  skeletonCount?: number
+  skeletonClassName?: string
+}
+
+export function PersonGrid<T extends PersonBase>({
   label,
   countLabel,
   members,
   isInView,
   animationDelay,
   onSelect,
-}: {
-  label: string
-  countLabel?: string
-  members: Gemeinderat[] | undefined
-  isInView: boolean
-  animationDelay: number
-  onSelect: (m: Gemeinderat) => void
-}) {
-  // Data loaded but section is empty — hide entirely rather than showing an empty heading
+  renderCardProps,
+  skeletonCount = 6,
+  skeletonClassName = 'h-64',
+}: PersonGridProps<T>) {
   if (members !== undefined && members.length === 0) return null
 
   return (
@@ -46,16 +59,16 @@ export function PersonGrid({
         animate={isInView ? 'visible' : 'hidden'}
         className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6"
       >
-        {members?.map(m => (
+        {members?.map((m, i) => (
           <PersonCard
             key={m.name}
             name={m.name}
             bildUrl={m.bildUrl}
-            sublabel={`seit ${m.seit}`}
-            onClick={() => onSelect(m)}
+            onClick={() => onSelect(m, i)}
+            {...renderCardProps?.(m, i)}
           />
         ))}
-        {!members && <SkeletonGrid count={6} itemClassName="h-64" />}
+        {!members && <SkeletonGrid count={skeletonCount} itemClassName={skeletonClassName} />}
       </motion.div>
     </div>
   )

--- a/src/components/sections/Aktuelles/index.tsx
+++ b/src/components/sections/Aktuelles/index.tsx
@@ -1,4 +1,4 @@
-import { useRef, useReducer, useEffect } from 'react'
+import { useRef, useEffect } from 'react'
 import { useInView } from 'framer-motion'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useData } from '@/hooks/useData'
@@ -7,6 +7,7 @@ import { useConfig } from '@/hooks/useConfig'
 import { useICSEvents } from '@/hooks/useICSEvents'
 import type { NewsItem } from '@/types/news'
 import type { ICSEvent } from '@/utils/icsParser'
+import { useSheetState } from '@/hooks/useSheetState'
 import Sheet from '@/components/Sheet'
 import SectionHeader from '@/components/SectionHeader'
 import NewsFeed from './NewsFeed'
@@ -16,34 +17,11 @@ import NewsDetailSheet from './NewsDetailSheet'
 import EventDetailSheet from './EventDetailSheet'
 import DayPickerSheet from './DayPickerSheet'
 
-// ---------------------------------------------------------------------------
-// Sheet state machine
-// ---------------------------------------------------------------------------
-
 type SheetState =
   | { type: 'none' }
   | { type: 'news'; item: NewsItem }
   | { type: 'event'; event: ICSEvent }
   | { type: 'dayPicker'; events: ICSEvent[] }
-
-type SheetAction =
-  | { type: 'openNews'; item: NewsItem }
-  | { type: 'openEvent'; event: ICSEvent }
-  | { type: 'openDayPicker'; events: ICSEvent[] }
-  | { type: 'close' }
-
-function sheetReducer(_: SheetState, action: SheetAction): SheetState {
-  switch (action.type) {
-    case 'openNews':
-      return { type: 'news', item: action.item }
-    case 'openEvent':
-      return { type: 'event', event: action.event }
-    case 'openDayPicker':
-      return { type: 'dayPicker', events: action.events }
-    case 'close':
-      return { type: 'none' }
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Component
@@ -55,7 +33,7 @@ export default function Aktuelles() {
   const ref = useRef<HTMLDivElement>(null)
   const isInView = useInView(ref, { once: true, margin: '-80px' })
 
-  const [sheet, dispatch] = useReducer(sheetReducer, { type: 'none' })
+  const { state: sheet, set: setSheet, close: closeSheet } = useSheetState<SheetState>({ type: 'none' })
 
   const { data: newsItems, error: newsError } = useData<NewsItem[]>('/data/news.json')
   const config = useConfig()
@@ -77,7 +55,7 @@ export default function Aktuelles() {
     if (!newsId || !newsItems) return
     const item = newsItems.find(n => (n.uuid ?? n.id) === newsId)
     if (item) {
-      dispatch({ type: 'openNews', item })
+      setSheet({ type: 'news', item })
     } else {
       navigate('/404', { replace: true })
     }
@@ -89,7 +67,7 @@ export default function Aktuelles() {
   }
 
   function handleCloseNewsSheet() {
-    dispatch({ type: 'close' })
+    closeSheet()
     navigate('/aktuelles', { replace: true })
   }
 
@@ -117,8 +95,8 @@ export default function Aktuelles() {
           loading={icsLoading}
           error={icsError}
           icsUrl={icsUrl}
-          onSelectEvent={event => dispatch({ type: 'openEvent', event })}
-          onSelectDayEvents={events => dispatch({ type: 'openDayPicker', events })}
+          onSelectEvent={event => setSheet({ type: 'event', event })}
+          onSelectDayEvents={events => setSheet({ type: 'dayPicker', events })}
         />
 
         <InstagramSection elfsightAppId={elfsightAppId} />
@@ -132,18 +110,18 @@ export default function Aktuelles() {
       {/* Day picker sheet (multiple events on the same day) */}
       <Sheet
         open={sheet.type === 'dayPicker' && sheet.events.length > 0}
-        onClose={() => dispatch({ type: 'close' })}
+        onClose={closeSheet}
       >
         {sheet.type === 'dayPicker' && (
           <DayPickerSheet
             events={sheet.events}
-            onSelect={event => dispatch({ type: 'openEvent', event })}
+            onSelect={event => setSheet({ type: 'event', event })}
           />
         )}
       </Sheet>
 
       {/* Event detail sheet */}
-      <Sheet open={sheet.type === 'event'} onClose={() => dispatch({ type: 'close' })}>
+      <Sheet open={sheet.type === 'event'} onClose={closeSheet}>
         {sheet.type === 'event' && <EventDetailSheet event={sheet.event} />}
       </Sheet>
     </section>

--- a/src/components/sections/Fraktion/index.tsx
+++ b/src/components/sections/Fraktion/index.tsx
@@ -1,43 +1,23 @@
-import { useRef, useReducer } from 'react'
+import { useRef } from 'react'
 import { motion, useInView } from 'framer-motion'
 import { useData } from '@/hooks/useData'
 import { useHttpErrorRedirect } from '@/hooks/useHttpErrorRedirect'
 import { useHaushaltsredenPagination } from '@/hooks/useHaushaltsredenPagination'
+import { useSheetState } from '@/hooks/useSheetState'
 import PersonSheet from '@/components/PersonSheet'
 import SectionHeader from '@/components/SectionHeader'
 import SubsectionLabel from '@/components/SubsectionLabel'
+import { PersonGrid } from '@/components/PersonGrid'
 import type { FraktionData, Gemeinderat } from './types'
-import { PersonGrid } from './PersonGrid'
 import { HaushaltsredeCard, HaushaltsredePlaceholder } from './HaushaltsredeCards'
 import { HaushaltsredenPagination } from './HaushaltsredenPagination'
-
-// ---------------------------------------------------------------------------
-// Sheet state machine
-// ---------------------------------------------------------------------------
-
-type SheetState = { type: 'none' } | { type: 'member'; member: Gemeinderat }
-
-type SheetAction = { type: 'openMember'; member: Gemeinderat } | { type: 'close' }
-
-function sheetReducer(_: SheetState, action: SheetAction): SheetState {
-  switch (action.type) {
-    case 'openMember':
-      return { type: 'member', member: action.member }
-    case 'close':
-      return { type: 'none' }
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Component
-// ---------------------------------------------------------------------------
 
 export default function Fraktion() {
   const ref = useRef(null)
   const isInView = useInView(ref, { once: true, margin: '-80px' })
   const { data, error } = useData<FraktionData>('/data/fraktion.json')
   useHttpErrorRedirect(error)
-  const [sheet, dispatch] = useReducer(sheetReducer, { type: 'none' })
+  const { state: selectedMember, set: openMember, close: closeMember } = useSheetState<Gemeinderat | null>(null)
 
   const {
     paginatedJahre,
@@ -67,7 +47,8 @@ export default function Fraktion() {
           members={data?.gemeinderaete}
           isInView={isInView}
           animationDelay={0.2}
-          onSelect={member => dispatch({ type: 'openMember', member })}
+          onSelect={openMember}
+          renderCardProps={m => ({ sublabel: `seit ${m.seit}` })}
         />
 
         <PersonGrid
@@ -76,7 +57,8 @@ export default function Fraktion() {
           members={data?.kreisraete}
           isInView={isInView}
           animationDelay={0.3}
-          onSelect={member => dispatch({ type: 'openMember', member })}
+          onSelect={openMember}
+          renderCardProps={m => ({ sublabel: `seit ${m.seit}` })}
         />
 
         {/* Haushaltsreden */}
@@ -114,9 +96,9 @@ export default function Fraktion() {
       </div>
 
       <PersonSheet
-        open={sheet.type === 'member'}
-        onClose={() => dispatch({ type: 'close' })}
-        person={sheet.type === 'member' ? sheet.member : null}
+        open={selectedMember !== null}
+        onClose={closeMember}
+        person={selectedMember}
       />
     </section>
   )

--- a/src/components/sections/Kommunalpolitik/index.tsx
+++ b/src/components/sections/Kommunalpolitik/index.tsx
@@ -5,10 +5,9 @@ import { useData } from '@/hooks/useData'
 import { useHttpErrorRedirect } from '@/hooks/useHttpErrorRedirect'
 import PersonSheet from '@/components/PersonSheet'
 import type { PersonSheetData } from '@/types/person'
-import PersonCard from '@/components/PersonCard'
-import { personCardContainerVariants } from '@/components/personCardVariants'
+import { PersonGrid } from '@/components/PersonGrid'
 import SectionHeader from '@/components/SectionHeader'
-import type { KommunalpolitikData } from './types'
+import type { KommunalpolitikData, KommunalpolitikPerson } from './types'
 import { DokumentCard } from './DokumentCard'
 
 export default function Kommunalpolitik() {
@@ -77,75 +76,29 @@ export default function Kommunalpolitik() {
             animate={{ opacity: 1 }}
             transition={{ duration: 0.3 }}
           >
-            {/* Gemeinderäte */}
-            {gemeinderaete.length > 0 && (
-              <div className="mb-20">
-                <motion.div
-                  initial={{ opacity: 0 }}
-                  animate={isInView ? { opacity: 1 } : {}}
-                  transition={{ delay: 0.2 }}
-                  className="mb-8"
-                >
-                  <h3 className="text-xs font-bold uppercase tracking-widest text-gray-400 dark:text-gray-500">
-                    Gemeinderatswahl {activeJahr.jahr}
-                  </h3>
-                  <p className="text-2xl font-black text-gray-900 dark:text-white mt-1">
-                    {gemeinderaete.length} {gemeinderaete.length === 1 ? 'Kandidat' : 'Kandidaten'}
-                  </p>
-                </motion.div>
-                <motion.div
-                  variants={personCardContainerVariants}
-                  initial="hidden"
-                  animate={isInView ? 'visible' : 'hidden'}
-                  className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6"
-                >
-                  {gemeinderaete.map((p, i) => (
-                    <PersonCard
-                      key={p.name}
-                      name={p.name}
-                      bildUrl={p.bildUrl}
-                      label={p.rolle ? `Listenplatz ${i + 1} · ${p.rolle}` : `Listenplatz ${i + 1}`}
-                      onClick={() => setSelectedPerson({ ...p, listenplatz: i + 1 })}
-                    />
-                  ))}
-                </motion.div>
-              </div>
-            )}
+            <PersonGrid<KommunalpolitikPerson>
+              label={`Gemeinderatswahl ${activeJahr.jahr}`}
+              countLabel={`${gemeinderaete.length} ${gemeinderaete.length === 1 ? 'Kandidat' : 'Kandidaten'}`}
+              members={gemeinderaete}
+              isInView={isInView}
+              animationDelay={0.2}
+              onSelect={(p, i) => setSelectedPerson({ ...p, listenplatz: i + 1 })}
+              renderCardProps={(p, i) => ({
+                label: p.rolle ? `Listenplatz ${i + 1} · ${p.rolle}` : `Listenplatz ${i + 1}`,
+              })}
+            />
 
-            {/* Kreisräte */}
-            {kreisraete.length > 0 && (
-              <div className="mb-20">
-                <motion.div
-                  initial={{ opacity: 0 }}
-                  animate={isInView ? { opacity: 1 } : {}}
-                  transition={{ delay: 0.3 }}
-                  className="mb-8"
-                >
-                  <h3 className="text-xs font-bold uppercase tracking-widest text-gray-400 dark:text-gray-500">
-                    Kreistagswahl {activeJahr.jahr}
-                  </h3>
-                  <p className="text-2xl font-black text-gray-900 dark:text-white mt-1">
-                    {kreisraete.length} {kreisraete.length === 1 ? 'Kandidat' : 'Kandidaten'}
-                  </p>
-                </motion.div>
-                <motion.div
-                  variants={personCardContainerVariants}
-                  initial="hidden"
-                  animate={isInView ? 'visible' : 'hidden'}
-                  className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6"
-                >
-                  {kreisraete.map((p, i) => (
-                    <PersonCard
-                      key={p.name}
-                      name={p.name}
-                      bildUrl={p.bildUrl}
-                      label={p.rolle ? `Listenplatz ${i + 1} · ${p.rolle}` : `Listenplatz ${i + 1}`}
-                      onClick={() => setSelectedPerson({ ...p, listenplatz: i + 1 })}
-                    />
-                  ))}
-                </motion.div>
-              </div>
-            )}
+            <PersonGrid<KommunalpolitikPerson>
+              label={`Kreistagswahl ${activeJahr.jahr}`}
+              countLabel={`${kreisraete.length} ${kreisraete.length === 1 ? 'Kandidat' : 'Kandidaten'}`}
+              members={kreisraete}
+              isInView={isInView}
+              animationDelay={0.3}
+              onSelect={(p, i) => setSelectedPerson({ ...p, listenplatz: i + 1 })}
+              renderCardProps={(p, i) => ({
+                label: p.rolle ? `Listenplatz ${i + 1} · ${p.rolle}` : `Listenplatz ${i + 1}`,
+              })}
+            />
 
             {/* Dokumente */}
             {dokumente.length > 0 && (

--- a/src/components/sections/Partei/index.tsx
+++ b/src/components/sections/Partei/index.tsx
@@ -1,8 +1,9 @@
-import { useRef, useReducer, useEffect } from 'react'
+import { useRef, useEffect } from 'react'
 import { motion, useInView } from 'framer-motion'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useData } from '@/hooks/useData'
 import { useHttpErrorRedirect } from '@/hooks/useHttpErrorRedirect'
+import { useSheetState } from '@/hooks/useSheetState'
 import PersonSheet from '@/components/PersonSheet'
 import PersonCard from '@/components/PersonCard'
 import { personCardContainerVariants } from '@/components/personCardVariants'
@@ -24,30 +25,10 @@ const PARTEI_BESCHREIBUNG_FALLBACK =
   'Bildungsgerechtigkeit: Wir sind die Stimme der Bürgerinnen und Bürger im Gemeinderat und setzen uns ' +
   'täglich dafür ein, dass Albstadt eine lebenswerte Stadt für alle bleibt. Werde Mitglied und gestalte mit!'
 
-// ---------------------------------------------------------------------------
-// Sheet state machine
-// ---------------------------------------------------------------------------
-
 type SheetState =
   | { type: 'none' }
   | { type: 'person'; person: Mitglied | Abgeordneter }
   | { type: 'schwerpunkt'; schwerpunkt: Schwerpunkt }
-
-type SheetAction =
-  | { type: 'openPerson'; person: Mitglied | Abgeordneter }
-  | { type: 'openSchwerpunkt'; schwerpunkt: Schwerpunkt }
-  | { type: 'close' }
-
-function sheetReducer(_: SheetState, action: SheetAction): SheetState {
-  switch (action.type) {
-    case 'openPerson':
-      return { type: 'person', person: action.person }
-    case 'openSchwerpunkt':
-      return { type: 'schwerpunkt', schwerpunkt: action.schwerpunkt }
-    case 'close':
-      return { type: 'none' }
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Component
@@ -60,14 +41,14 @@ export default function Partei() {
   const isInView = useInView(ref, { once: true, margin: '-80px' })
   const { data, error } = useData<PartyData>('/data/party.json')
   useHttpErrorRedirect(error)
-  const [sheet, dispatch] = useReducer(sheetReducer, { type: 'none' })
+  const { state: sheet, set: setSheet, close: closeSheet } = useSheetState<SheetState>({ type: 'none' })
 
   // Sync URL param → sheet state once data is loaded.
   useEffect(() => {
     if (!schwerpunktSlug || !data) return
     const match = data.schwerpunkte.find(s => slugify(s.titel) === schwerpunktSlug)
     if (match) {
-      dispatch({ type: 'openSchwerpunkt', schwerpunkt: match })
+      setSheet({ type: 'schwerpunkt', schwerpunkt: match })
     } else {
       navigate('/404', { replace: true })
     }
@@ -79,7 +60,7 @@ export default function Partei() {
   }
 
   function handleCloseSchwerpunkt() {
-    dispatch({ type: 'close' })
+    closeSheet()
     navigate('/partei', { replace: true })
   }
 
@@ -129,7 +110,7 @@ export default function Partei() {
                   bildUrl={m.bildUrl}
                   label={m.rolle}
                   priority={i === 0}
-                  onClick={() => dispatch({ type: 'openPerson', person: m })}
+                  onClick={() => setSheet({ type: 'person', person: m })}
                 />
               ))}
               {!data && <SkeletonGrid count={9} itemClassName="aspect-3/4" />}
@@ -157,7 +138,7 @@ export default function Partei() {
                     key={a.name}
                     a={a}
                     priority={i === 0}
-                    onClick={() => dispatch({ type: 'openPerson', person: a })}
+                    onClick={() => setSheet({ type: 'person', person: a })}
                   />
                 ))}
               </motion.div>
@@ -168,7 +149,7 @@ export default function Partei() {
 
       <PersonSheet
         open={sheet.type === 'person'}
-        onClose={() => dispatch({ type: 'close' })}
+        onClose={closeSheet}
         person={sheet.type === 'person' ? sheet.person : null}
       />
 

--- a/src/hooks/useSheetState.ts
+++ b/src/hooks/useSheetState.ts
@@ -1,0 +1,11 @@
+import { useState } from 'react'
+
+/**
+ * Minimal sheet/modal state: tracks what's open, provides open (set) and close helpers.
+ * Pass the "closed" sentinel as the initial value — null for single-type sheets,
+ * { type: 'none' } for discriminated-union multi-type sheets.
+ */
+export function useSheetState<S>(closed: S) {
+  const [state, setState] = useState<S>(closed)
+  return { state, set: setState, close: () => setState(closed) }
+}


### PR DESCRIPTION
## Summary

- **`useSheetState<S>` hook** — replaces copy-pasted `SheetAction` type + `sheetReducer` + `useReducer` in Fraktion, Partei, and Aktuelles with a single 5-line hook
- **Shared `PersonGrid<T>` component** — moved from `Fraktion/PersonGrid.tsx` to `components/PersonGrid.tsx` as a generic component; now used by Fraktion and Kommunalpolitik instead of inline motion grids
- Net result: −82 lines, zero behaviour changes, TypeScript clean

---
_Generated by [Claude Code](https://claude.ai/code/session_016X5f8H53ABJPKsN9RakhuS)_