### PR TITLE
refactor: extract SectionContainer and fix Kommunalpolitik skeleton

### DIFF
--- a/src/components/SectionContainer.tsx
+++ b/src/components/SectionContainer.tsx
@@ -1,0 +1,19 @@
+import { type ReactNode } from 'react'
+
+interface SectionContainerProps {
+  id: string
+  className?: string
+  children: ReactNode
+}
+
+export default function SectionContainer({
+  id,
+  className = 'bg-gray-50 dark:bg-gray-900',
+  children,
+}: SectionContainerProps) {
+  return (
+    <section id={id} className={`py-24 ${className}`}>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">{children}</div>
+    </section>
+  )
+}

--- a/src/components/sections/Aktuelles/index.tsx
+++ b/src/components/sections/Aktuelles/index.tsx
@@ -8,6 +8,7 @@ import type { ICSEvent } from '@/utils/icsParser'
 import { useSheetState } from '@/hooks/useSheetState'
 import Sheet from '@/components/Sheet'
 import SectionHeader from '@/components/SectionHeader'
+import SectionContainer from '@/components/SectionContainer'
 import NewsFeed from './NewsFeed'
 import CalendarSection from './CalendarSection'
 import InstagramSection from './InstagramSection'
@@ -69,8 +70,8 @@ export default function Aktuelles() {
   }
 
   return (
-    <section id="aktuelles" className="py-24 bg-gray-50 dark:bg-gray-900">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <>
+      <SectionContainer id="aktuelles">
         <SectionHeader
           sectionRef={ref}
           isInView={isInView}
@@ -97,14 +98,12 @@ export default function Aktuelles() {
         />
 
         <InstagramSection elfsightAppId={elfsightAppId} />
-      </div>
+      </SectionContainer>
 
-      {/* News detail sheet */}
       <Sheet open={sheet.type === 'news'} onClose={handleCloseNewsSheet} size="lg">
         {sheet.type === 'news' && <NewsDetailSheet news={sheet.item} />}
       </Sheet>
 
-      {/* Day picker sheet (multiple events on the same day) */}
       <Sheet open={sheet.type === 'dayPicker' && sheet.events.length > 0} onClose={closeSheet}>
         {sheet.type === 'dayPicker' && (
           <DayPickerSheet
@@ -114,10 +113,9 @@ export default function Aktuelles() {
         )}
       </Sheet>
 
-      {/* Event detail sheet */}
       <Sheet open={sheet.type === 'event'} onClose={closeSheet}>
         {sheet.type === 'event' && <EventDetailSheet event={sheet.event} />}
       </Sheet>
-    </section>
+    </>
   )
 }

--- a/src/components/sections/Fraktion/index.tsx
+++ b/src/components/sections/Fraktion/index.tsx
@@ -9,6 +9,7 @@ import { PersonGrid } from '@/components/PersonGrid'
 import type { FraktionData, Gemeinderat } from './types'
 import { HaushaltsredeCard, HaushaltsredePlaceholder } from './HaushaltsredeCards'
 import { HaushaltsredenPagination } from './HaushaltsredenPagination'
+import SectionContainer from '@/components/SectionContainer'
 
 export default function Fraktion() {
   const { ref, isInView, data } = useSectionPage<FraktionData>('/data/fraktion.json')
@@ -30,8 +31,8 @@ export default function Fraktion() {
   } = useHaushaltsredenPagination()
 
   return (
-    <section id="fraktion" className="py-24 bg-gray-50 dark:bg-gray-900">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <>
+      <SectionContainer id="fraktion">
         <SectionHeader
           sectionRef={ref}
           isInView={isInView}
@@ -92,9 +93,9 @@ export default function Fraktion() {
             onLoadLess={loadLessReden}
           />
         </motion.div>
-      </div>
+      </SectionContainer>
 
       <PersonSheet open={selectedMember !== null} onClose={closeMember} person={selectedMember} />
-    </section>
+    </>
   )
 }

--- a/src/components/sections/Historie/index.tsx
+++ b/src/components/sections/Historie/index.tsx
@@ -6,6 +6,7 @@ import Sheet from '@/components/Sheet'
 import PersonSheet from '@/components/PersonSheet'
 import SectionHeader from '@/components/SectionHeader'
 import { SkeletonGrid } from '@/components/SkeletonGrid'
+import SectionContainer from '@/components/SectionContainer'
 import { TIMELINE_TYPE_META } from './types'
 import { TimelineRow } from './TimelineRow'
 import { EventSheet } from './EventSheet'
@@ -17,7 +18,7 @@ export default function Historie() {
   const { data, merged, sheet, openEvent, openPerson, closeSheet } = useHistorie(jahreSlug)
 
   return (
-    <section id="historie" className="py-24 bg-gray-50 dark:bg-gray-900">
+    <>
       {sheet.type === 'event' && (
         <Helmet>
           <title>
@@ -42,8 +43,8 @@ export default function Historie() {
           <meta name="twitter:description" content={sheet.entry.beschreibung.slice(0, 160)} />
         </Helmet>
       )}
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        {/* Header */}
+
+      <SectionContainer id="historie">
         <SectionHeader
           sectionRef={ref}
           isInView={isInView}
@@ -98,19 +99,17 @@ export default function Historie() {
             <SkeletonGrid count={4} itemClassName="h-24" />
           </div>
         )}
-      </div>
+      </SectionContainer>
 
-      {/* Event detail sheet */}
       <Sheet open={sheet.type === 'event'} onClose={closeSheet} size="lg">
         {sheet.type === 'event' && <EventSheet entry={sheet.entry} />}
       </Sheet>
 
-      {/* Person detail sheet */}
       <PersonSheet
         open={sheet.type === 'person'}
         onClose={closeSheet}
         person={sheet.type === 'person' ? sheet.person : null}
       />
-    </section>
+    </>
   )
 }

--- a/src/components/sections/Kommunalpolitik/index.tsx
+++ b/src/components/sections/Kommunalpolitik/index.tsx
@@ -6,6 +6,8 @@ import PersonSheet from '@/components/PersonSheet'
 import type { PersonSheetData } from '@/types/person'
 import { PersonGrid } from '@/components/PersonGrid'
 import SectionHeader from '@/components/SectionHeader'
+import { SkeletonGrid } from '@/components/SkeletonGrid'
+import SectionContainer from '@/components/SectionContainer'
 import type { KommunalpolitikData, KommunalpolitikPerson } from './types'
 import { DokumentCard } from './DokumentCard'
 
@@ -31,8 +33,8 @@ export default function Kommunalpolitik() {
   const hasContent = gemeinderaete.length > 0 || kreisraete.length > 0 || dokumente.length > 0
 
   return (
-    <section id="kommunalpolitik" className="py-24 bg-white dark:bg-gray-950">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <>
+      <SectionContainer id="kommunalpolitik" className="bg-white dark:bg-gray-950">
         <SectionHeader
           sectionRef={ref}
           isInView={isInView}
@@ -126,21 +128,16 @@ export default function Kommunalpolitik() {
         {/* Skeleton while loading */}
         {!data && (
           <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6">
-            {Array.from({ length: 4 }).map((_, i) => (
-              <div
-                key={i}
-                className="bg-gray-100 dark:bg-gray-800 rounded-2xl h-64 animate-pulse"
-              />
-            ))}
+            <SkeletonGrid count={4} itemClassName="h-64" />
           </div>
         )}
-      </div>
+      </SectionContainer>
 
       <PersonSheet
         open={!!selectedPerson}
         onClose={() => setSelectedPerson(null)}
         person={selectedPerson}
       />
-    </section>
+    </>
   )
 }

--- a/src/components/sections/Partei/index.tsx
+++ b/src/components/sections/Partei/index.tsx
@@ -14,6 +14,7 @@ import type { Mitglied, Abgeordneter, PartyData, Schwerpunkt } from './types'
 import { AbgeordneterCard } from './AbgeordneterCard'
 import { SchwerpunktCard } from './SchwerpunktCard'
 import { SchwerpunktSheet } from './SchwerpunktSheet'
+import SectionContainer from '@/components/SectionContainer'
 
 // Static fallback used before party.json loads so SectionHeader always reserves
 // the correct height for the description paragraph, preventing CLS.
@@ -65,8 +66,8 @@ export default function Partei() {
   }
 
   return (
-    <section id="partei" className="py-24 bg-gray-50 dark:bg-gray-900">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <>
+      <SectionContainer id="partei">
         <SectionHeader
           sectionRef={ref}
           isInView={isInView}
@@ -145,7 +146,7 @@ export default function Partei() {
             )}
           </div>
         )}
-      </div>
+      </SectionContainer>
 
       <PersonSheet
         open={sheet.type === 'person'}
@@ -157,6 +158,6 @@ export default function Partei() {
         item={sheet.type === 'schwerpunkt' ? sheet.schwerpunkt : null}
         onClose={handleCloseSchwerpunkt}
       />
-    </section>
+    </>
   )
 }


### PR DESCRIPTION
Eliminates the repeated `<section>/<div>` wrapper pattern duplicated across 5 section pages and fixes an inconsistent skeleton loader.

## Changes

**New `SectionContainer` component** — replaces ~10 lines of identical boilerplate in every section:
```jsx
<section id="…" className="py-24 bg-gray-50 dark:bg-gray-900">
  <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
```
Applied to: Aktuelles, Partei, Fraktion, Kommunalpolitik, Historie. Kontakt is left as-is (has a `GridBackground` sibling and `relative z-10` on the inner div).

**Kommunalpolitik skeleton** — replaces the hand-rolled `Array.from({length:4}).map(…)` with `<SkeletonGrid count={4} itemClassName="h-64" />`, consistent with all other sections.

---
_Generated by [Claude Code](https://claude.ai/code/session_011AjTXbWFrr4XntXR7SQNf5)_