### PR TITLE
Consolidate Kommunalpolitik type definitions + fix CI format check

### DIFF
--- a/scripts/find-unused-assets.mjs
+++ b/scripts/find-unused-assets.mjs
@@ -19,7 +19,11 @@ function walk(dir) {
 }
 
 function readText(file) {
-  try { return readFileSync(file, 'utf8') } catch { return '' }
+  try {
+    return readFileSync(file, 'utf8')
+  } catch {
+    return ''
+  }
 }
 
 // 1. Collect all asset files on disk (relative public URL form: /images/... /documents/...)
@@ -28,7 +32,7 @@ const docsDir = join(ROOT, 'public/documents')
 
 const assetFiles = new Set()
 for (const f of walk(imageDir)) assetFiles.add('/' + relative(join(ROOT, 'public'), f))
-for (const f of walk(docsDir))  assetFiles.add('/' + relative(join(ROOT, 'public'), f))
+for (const f of walk(docsDir)) assetFiles.add('/' + relative(join(ROOT, 'public'), f))
 
 // 2. Collect all referenced paths from JSON data files
 const referencedPaths = new Set()
@@ -73,7 +77,7 @@ if (unused.length === 0) {
   console.log('No unused assets found.')
 } else {
   const images = unused.filter(f => f.startsWith('/images/'))
-  const docs   = unused.filter(f => f.startsWith('/documents/'))
+  const docs = unused.filter(f => f.startsWith('/documents/'))
   if (images.length) {
     console.log('--- Unused images ---')
     images.forEach(f => console.log(' ', f))

--- a/src/admin/__tests__/coverage-gaps2.test.tsx
+++ b/src/admin/__tests__/coverage-gaps2.test.tsx
@@ -1494,7 +1494,7 @@ describe('HaushaltsredenEditor — silent error handling (line 88/201)', () => {
 // ─── useKommunalpolitikEditor.ts lines 125-166 — all action functions ─────────
 
 import { useKommunalpolitikEditor } from '../../admin/hooks/useKommunalpolitikEditor'
-import type { Dokument as _Dokument } from '../../admin/hooks/useKommunalpolitikEditor'
+import type { Dokument as _Dokument } from '../../components/sections/Kommunalpolitik/types'
 
 function UseKommunalpolitikWrapper() {
   const editor = useKommunalpolitikEditor()

--- a/src/admin/components/KommunalpolitikEditor.tsx
+++ b/src/admin/components/KommunalpolitikEditor.tsx
@@ -18,11 +18,8 @@ import { CollapsibleSectionHeader } from './CollapsibleSection'
 import { fileToBase64 } from '../lib/images'
 import { openPendingFile } from '../lib/fileUtils'
 import { inputCls } from '../lib/inputCls'
-import {
-  useKommunalpolitikEditor,
-  PERSON_FIELDS,
-  type Dokument,
-} from '../hooks/useKommunalpolitikEditor'
+import { useKommunalpolitikEditor, PERSON_FIELDS } from '../hooks/useKommunalpolitikEditor'
+import type { Dokument } from '@/components/sections/Kommunalpolitik/types'
 
 export default function KommunalpolitikEditor() {
   const {

--- a/src/admin/hooks/useKommunalpolitikEditor.ts
+++ b/src/admin/hooks/useKommunalpolitikEditor.ts
@@ -7,38 +7,12 @@ import { useAdminStore } from '../store'
 import type { FieldConfig } from '../types'
 import { useUndoRedoShortcuts } from './useUndoRedoShortcuts'
 import { useTabPublisher } from './useTabPublisher'
-
-// ─── Domain types ─────────────────────────────────────────────────────────────
-
-interface KommunalpolitikPerson {
-  name: string
-  rolle?: string
-  bildUrl?: string
-  email?: string
-  bio?: string
-  stadt?: string
-}
-
-export interface Dokument {
-  id: string
-  titel: string
-  url: string
-}
-
-interface KommunalpolitikJahr {
-  id: string
-  jahr: string
-  aktiv: boolean
-  gemeinderaete: KommunalpolitikPerson[]
-  kreisraete: KommunalpolitikPerson[]
-  dokumente: Dokument[]
-}
-
-interface KommunalpolitikData {
-  sichtbar: boolean
-  beschreibung: string
-  jahre: KommunalpolitikJahr[]
-}
+import type {
+  Dokument,
+  KommunalpolitikData,
+  KommunalpolitikJahr,
+  KommunalpolitikPerson,
+} from '@/components/sections/Kommunalpolitik/types'
 
 export const PERSON_FIELDS: FieldConfig[] = [
   { key: 'name', label: 'Name', type: 'text', required: true },

--- a/src/components/PersonSheet.tsx
+++ b/src/components/PersonSheet.tsx
@@ -3,7 +3,6 @@ import Sheet from './Sheet'
 import PhotoGallery from './PhotoGallery'
 import type { PersonSheetData } from '../types/person'
 
-
 const getInitials = (name: string) =>
   name
     .split(' ')

--- a/src/components/sections/Kommunalpolitik/types.ts
+++ b/src/components/sections/Kommunalpolitik/types.ts
@@ -13,7 +13,7 @@ export interface Dokument {
   url: string
 }
 
-interface KommunalpolitikJahr {
+export interface KommunalpolitikJahr {
   id: string
   jahr: string
   aktiv: boolean

--- a/src/seoConfig.ts
+++ b/src/seoConfig.ts
@@ -118,4 +118,3 @@ export const SEO_CONFIG: Record<string, SEOMeta> = {
     priority: 0.3,
   },
 }
-


### PR DESCRIPTION
## Summary

- Remove duplicate `KommunalpolitikPerson`, `KommunalpolitikJahr`, `KommunalpolitikData`, and `Dokument` type definitions from the admin hook — now imported from the canonical `src/components/sections/Kommunalpolitik/types.ts`
- Fix Prettier formatting on 3 files (`scripts/find-unused-assets.mjs`, `src/components/PersonSheet.tsx`, `src/seoConfig.ts`) that caused the CI format check to fail after PR #54

## Files changed

- `src/components/sections/Kommunalpolitik/types.ts` — re-export `KommunalpolitikJahr` so admin hook can import it
- `src/admin/hooks/useKommunalpolitikEditor.ts` — replace 29 lines of duplicate type definitions with a single import
- `src/admin/components/KommunalpolitikEditor.tsx` — import `Dokument` from shared types file
- `src/admin/__tests__/coverage-gaps2.test.tsx` — update `Dokument` import to shared types file
- `scripts/find-unused-assets.mjs`, `src/components/PersonSheet.tsx`, `src/seoConfig.ts` — Prettier formatting fixes

---
_Generated by [Claude Code](https://claude.ai/code/session_016auyhTvV2FPhVpti4Zhe1E)_