### PR TITLE
Add toggle and time to documented FieldConfig types in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,7 +309,7 @@ Every editor tab is declared in `src/admin/config/tabs.ts` as a `TabConfig`. To 
 }
 ```
 
-**`FieldConfig` types:** `text`, `textarea`, `date`, `email`, `url`, `select`, `image`, `imagelist`, `icon-picker`, `stringlist`
+**`FieldConfig` types:** `text`, `textarea`, `date`, `time`, `email`, `url`, `select`, `toggle`, `image`, `imagelist`, `icon-picker`, `stringlist`
 
 For `image` fields, set `imageDir` to the target subdirectory under `public/images/` (e.g. `imageDir: 'vorstand'`).  
 For `imagelist` fields, set `captionsKey` to the companion string-array field if captions are supported.


### PR DESCRIPTION
Both `toggle` and `time` exist in the `FieldConfig` type union in `src/admin/types.ts` but were missing from the CLAUDE.md reference list. One-line fix.

https://claude.ai/code/session_016auyhTvV2FPhVpti4Zhe1E

---
_Generated by [Claude Code](https://claude.ai/code/session_016auyhTvV2FPhVpti4Zhe1E)_