### PR TITLE
fix: remove unused useDarkMode call from App

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,13 +8,11 @@ import PageLayout from './components/PageLayout'
 import ErrorBoundary from './components/ErrorBoundary'
 import LoadingSpinner from './components/LoadingSpinner'
 import SEOHead from './components/SEOHead'
-import { useDarkMode } from './hooks/useDarkMode'
 import { ROUTES, CATCH_ALL_ROUTE, PAGE_TITLES, DEPTH } from './routeConfig'
 
 const AdminApp = lazy(() => import('./admin/AdminApp'))
 
 export default function App() {
-  const { darkMode } = useDarkMode()
   const [showScrollTop, setShowScrollTop] = useState(false)
   const location = useLocation()
   const prevPathRef = useRef(location.pathname)


### PR DESCRIPTION
## Summary

Commit `525a84a` moved the dark-mode toggle from `App.tsx` to `Hero.tsx` but left a dangling `const { darkMode } = useDarkMode()` behind. That broke the CI on `main`:

- **Type-check** — `src/App.tsx(17,9): error TS6133: 'darkMode' is declared but its value is never read.`
- **Lint** — `'darkMode' is assigned a value but never used  @typescript-eslint/no-unused-vars`

This PR removes the unused destructured value and the now-unused import. The `useDarkMode` side-effect (applying the `dark` class to `<html>` and writing to `localStorage`) is still triggered by `Navbar` on non-home routes and `Hero` on `/`, so behavior is unchanged.

## Test plan

- [x] `npm run build` — passes
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm test` — 39 files / 896 tests passing
- [x] `npm run knip` — no unused exports
- [x] `npm run find-unused-assets` — no orphans

---
_Generated by [Claude Code](https://claude.ai/code/session_018XqefEQccNoSvVba3SUHUL)_