### PR TITLE
content: add detail text to all Schwerpunkte

### DIFF
--- a/public/data/party.json
+++ b/public/data/party.json
@@ -5,32 +5,37 @@
       "titel": "Bildung und Jugend",
       "beschreibung": "Gute Bildung für alle Kinder – unabhängig von Herkunft oder Geldbeutel. Wir investieren in Kitas, Schulen und Jugendzentren.",
       "icon": "GraduationCap",
-      "inhalt": ""
+      "inhalt": "Bildung ist die Grundlage für ein selbstbestimmtes Leben und gleichzeitig der Schlüssel für die Zukunft unserer Stadt. Die SPD Albstadt setzt sich dafür ein, dass jedes Kind – egal aus welcher Familie es stammt – die bestmögliche Förderung erhält.\n\nWir wollen mehr Kitaplätze schaffen, Betreuungszeiten ausweiten und die Qualität der frühkindlichen Bildung verbessern. In den Schulen kämpfen wir für kleinere Klassen, moderne Ausstattung und gut ausgebildetes Personal.\n\nJugendzentren und offene Jugendarbeit sind für uns keine Freiwilligkeit, sondern eine kommunale Pflichtaufgabe. Junge Menschen brauchen Orte, an denen sie sich entfalten, engagieren und gehört fühlen. Wir stehen an ihrer Seite."
     },
     {
       "titel": "Soziales und Wohnen",
       "beschreibung": "Bezahlbares Wohnen und starke soziale Absicherung für alle Albstädter Bürgerinnen und Bürger.",
-      "icon": "Home"
+      "icon": "Home",
+      "inhalt": "Wohnen ist ein Grundbedürfnis – und darf kein Luxus sein. Die SPD Albstadt setzt sich für eine aktive kommunale Wohnungspolitik ein: mehr Sozialwohnungen, kommunale Belegungsrechte und ein verantwortungsvoller Umgang mit städtischen Grundstücken.\n\nWir unterstützen Menschen, die auf Hilfe angewiesen sind: ob durch Beratungsangebote, niedrigschwellige Anlaufstellen oder die Stärkung der sozialen Infrastruktur vor Ort. Niemand soll in Albstadt allein gelassen werden.\n\nSolidarität bedeutet für uns nicht nur ein Wort, sondern gelebte Praxis. Deshalb setzen wir uns im Gemeinderat konsequent für Maßnahmen ein, die den Zusammenhalt in unserer Stadt stärken – für alle Generationen."
     },
     {
       "titel": "Klimaschutz und Umwelt",
       "beschreibung": "Erneuerbare Energien, Windkraft auf Albstädter Höhen, nachhaltige Stadtentwicklung und mehr Grünflächen.",
-      "icon": "Leaf"
+      "icon": "Leaf",
+      "inhalt": "Der Klimawandel macht auch vor Albstadt nicht halt. Die SPD setzt auf konkrete kommunale Maßnahmen: Windkraft auf den Albstädter Höhen, Ausbau von Photovoltaik auf städtischen Gebäuden und eine klimafreundliche Bauleitplanung.\n\nWir wollen mehr Grünflächen im Stadtgebiet erhalten und neu schaffen – als Lebensraum für Mensch und Tier und als natürlicher Hitzeschutz. Bäume, Parks und begrünte Fassaden sind für uns keine Dekoration, sondern klimapolitische Notwendigkeit.\n\nNachhaltige Stadtentwicklung denkt Klimaschutz und Lebensqualität zusammen. Wir setzen uns dafür ein, dass Albstadt beim ökologischen Wandel vorangeht – ohne die sozialen Folgen aus dem Blick zu verlieren."
     },
     {
       "titel": "Mobilität und ÖPNV",
       "beschreibung": "Talgangbahn, bessere Busverbindungen, sichere Radwege. Wir kämpfen für eine echte Verkehrswende in Albstadt.",
-      "icon": "Bus"
+      "icon": "Bus",
+      "inhalt": "Mobilität entscheidet darüber, wie selbstständig Menschen am gesellschaftlichen Leben teilnehmen können. Die SPD Albstadt kämpft für einen starken öffentlichen Nahverkehr – als Alternative zum Auto, nicht als Notlösung.\n\nDie Talgangbahn ist für uns ein Herzensanliegen: eine moderne Stadtbahn, die die Albstädter Stadtteile verbindet und Tausende von Pendlerinnen und Pendlern täglich entlastet. Wir treiben dieses Projekt im Gemeinderat aktiv voran.\n\nDaneben setzen wir uns für ein dichteres Busnetz, verlässlichere Takte und sichere Radwege ein. Wer in Albstadt ohne Auto mobil sein will, soll das ohne Kompromisse tun können."
     },
     {
       "titel": "Wirtschaft und Arbeit",
       "beschreibung": "Gute Arbeit und faire Löhne. Wir unterstützen lokale Betriebe und schaffen neu, zukunftssichere Arbeitsplätze.",
-      "icon": "Briefcase"
+      "icon": "Briefcase",
+      "inhalt": "Albstadt hat eine starke industrielle Tradition – und wir wollen diese Stärke in die Zukunft tragen. Die SPD steht für gute Arbeit: mit fairen Löhnen, sicheren Arbeitsplätzen und echten Mitbestimmungsrechten für die Beschäftigten.\n\nWir unterstützen lokale Unternehmen bei der Transformation: ob Digitalisierung, Energiewende oder Fachkräftemangel. Die Stadt soll dabei aktiver Partner sein – durch gezielte Wirtschaftsförderung, schnelle Genehmigungsverfahren und bezahlbare Gewerberäume.\n\nGleichzeitig setzen wir auf die Ansiedlung zukunftssicherer Branchen. Albstadt soll ein attraktiver Wirtschaftsstandort bleiben – für bestehende Betriebe und neue Ideen."
     },
     {
       "titel": "Demokratie und Teilhabe",
       "beschreibung": "Bürgerbeteiligung stärken, Transparenz fördern und alle Albstädter in politische Entscheidungen einbeziehen.",
-      "icon": "Users"
+      "icon": "Users",
+      "inhalt": "Demokratie lebt von Menschen, die mitmachen. Die SPD Albstadt will Bürgerbeteiligung nicht als Pflichtübung, sondern als echten Bestandteil kommunaler Entscheidungsprozesse etablieren.\n\nWir setzen uns für mehr Transparenz im Gemeinderat ein: nachvollziehbare Entscheidungen, offene Sitzungen und verständliche Kommunikation mit den Bürgerinnen und Bürgern. Wer wissen will, was in seiner Stadt entschieden wird, soll das ohne Hürden erfahren können.\n\nBesonders wichtig ist uns die Einbeziehung von Menschen, die in der Politik oft weniger gehört werden – junge Albstädter, Menschen mit Migrationshintergrund, Familien und Ältere. Eine lebendige Demokratie braucht alle Stimmen."
     }
   ],
   "vorstand": [


### PR DESCRIPTION
## Summary

- Adds a full German `inhalt` text (3 paragraphs) to each of the 6 Schwerpunkte in `public/data/party.json`
- Text appears in the detail sheet when a Schwerpunkt card is tapped on the Partei page
- Content is Albstadt-specific (e.g. Talgangbahn, Windkraft auf den Albstädter Höhen)
- Also editable via Admin → Partei → Schwerpunkte → Ausführlicher Text

## Test plan

- [ ] Open /partei, tap a Schwerpunkt card, confirm detail text appears in the sheet
- [ ] Verify all 6 cards show their respective texts

https://claude.ai/code/session_013p397QeKbBLZMx8nhaX4ad

---
_Generated by [Claude Code](https://claude.ai/code/session_013p397QeKbBLZMx8nhaX4ad)_