### PR TITLE
Fix admin editor bugs from code review

### DIFF
--- a/api/auth/callback.ts
+++ b/api/auth/callback.ts
@@ -5,6 +5,11 @@ import { rateLimit, getClientIP } from './rateLimit.js'
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   res.setHeader('Cache-Control', 'no-store')
 
+  if (req.method !== 'GET') {
+    res.status(405).json({ error: 'method_not_allowed' })
+    return
+  }
+
   // Rate limit: 10 callback attempts per IP per minute to prevent code stuffing.
   const ip = getClientIP(req.headers as Record<string, string | string[] | undefined>)
   if (!rateLimit(ip, 10, 60_000)) {

--- a/api/auth/session.ts
+++ b/api/auth/session.ts
@@ -20,6 +20,10 @@ import {
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   res.setHeader('Cache-Control', 'no-store')
 
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'method_not_allowed' })
+  }
+
   // Only allow same-origin requests
   const origin = req.headers['origin'] ?? ''
   if (origin && !isAllowedOrigin(origin)) {

--- a/api/auth/start.ts
+++ b/api/auth/start.ts
@@ -9,10 +9,14 @@ import { rateLimit, getClientIP } from './rateLimit.js'
  * Generates a signed CSRF state, stores it in an HttpOnly cookie,
  * and redirects the user to GitHub's OAuth authorize endpoint.
  */
-export default function handler(_req: VercelRequest, res: VercelResponse) {
+export default function handler(req: VercelRequest, res: VercelResponse) {
   res.setHeader('Cache-Control', 'no-store')
+  if (req.method !== 'GET') {
+    res.status(405).json({ error: 'method_not_allowed' })
+    return
+  }
   // Rate limit: 5 login attempts per IP per minute
-  const ip = getClientIP(_req.headers as Record<string, string | string[] | undefined>)
+  const ip = getClientIP(req.headers as Record<string, string | string[] | undefined>)
   if (!rateLimit(ip, 5, 60_000)) {
     res.status(429).json({ error: 'too_many_requests' })
     return

--- a/api/ics.ts
+++ b/api/ics.ts
@@ -47,8 +47,9 @@ export default async function handler(_req: VercelRequest, res: VercelResponse) 
     res.setHeader('Content-Type', 'text/calendar; charset=utf-8')
     res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate')
     res.status(200).end(body)
-  } catch (err) {
+  } catch {
+    // Opaque code only — raw error messages can leak internal hostnames/paths
     res.setHeader('Content-Type', 'application/json')
-    res.status(502).json({ error: err instanceof Error ? err.message : 'Unknown error' })
+    res.status(502).json({ error: 'upstream_error' })
   }
 }

--- a/src/admin/__tests__/imageFieldUrlInput.test.tsx
+++ b/src/admin/__tests__/imageFieldUrlInput.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { useState } from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import ImageField from '../fields/ImageField'
+
+const field = { key: 'bild', label: 'Bild', type: 'image' as const, imageDir: 'news' }
+
+// Controlled harness — mirrors how FieldRenderer feeds the store value back as a prop.
+// A plain mocked onChange would never update `value` and miss sync-block regressions.
+function Harness({ initial = '' }: { initial?: string }) {
+  const [value, setValue] = useState(initial)
+  return <ImageField field={field} value={value} onChange={setValue} />
+}
+
+const urlInput = () => screen.queryByPlaceholderText('/images/... oder https://...')
+
+describe('ImageField — manual URL entry (controlled)', () => {
+  it('keeps the URL input open while the user types', () => {
+    render(<Harness />)
+    const input = urlInput()
+    expect(input).not.toBeNull()
+    fireEvent.change(input!, { target: { value: '/i' } })
+    expect(urlInput()).not.toBeNull()
+    fireEvent.change(urlInput()!, { target: { value: '/images/news/foto.webp' } })
+    expect(urlInput()).not.toBeNull()
+    expect((urlInput() as HTMLInputElement).value).toBe('/images/news/foto.webp')
+  })
+
+  it('still resets the URL input on external value changes (item switch)', () => {
+    const { rerender } = render(
+      <ImageField field={field} value="/images/news/a.webp" onChange={() => {}} />,
+    )
+    expect(urlInput()).toBeNull()
+    rerender(<ImageField field={field} value="" onChange={() => {}} />)
+    expect(urlInput()).not.toBeNull()
+  })
+})

--- a/src/admin/components/ArrayEditor.tsx
+++ b/src/admin/components/ArrayEditor.tsx
@@ -12,6 +12,7 @@ import {
   useSensors,
 } from '@dnd-kit/core'
 import {
+  arrayMove,
   SortableContext,
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
@@ -33,6 +34,15 @@ export default function ArrayEditor({ fields, data, tabKey, onStructureChange }:
   const updateState = useAdminStore(s => s.updateState)
   const [activeId, setActiveId] = useState<string | null>(null)
   const [filter, setFilter] = useState('')
+
+  // Stable UUIDs for sortable/React keys — most data items carry no `id` field,
+  // and index-based ids would misattach card UI state after remove/reorder.
+  // Every local mutation updates the id array in tandem with the data; external
+  // length changes (undo/redo/revert/discard) are re-synced during render.
+  const [ids, setIds] = useState<string[]>(() => data.map(() => crypto.randomUUID()))
+  if (ids.length !== data.length) {
+    setIds(data.map((_, i) => ids[i] ?? crypto.randomUUID()))
+  }
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -60,6 +70,7 @@ export default function ArrayEditor({ fields, data, tabKey, onStructureChange }:
   }
 
   const handleMove = (from: number, to: number) => {
+    setIds(arrayMove(ids, from, to))
     const newArr = [...data]
     const [moved] = newArr.splice(from, 1)
     newArr.splice(to, 0, moved)
@@ -67,6 +78,7 @@ export default function ArrayEditor({ fields, data, tabKey, onStructureChange }:
   }
 
   const handleRemove = (index: number) => {
+    setIds(ids.filter((_, i) => i !== index))
     const newArr = data.filter((_, i) => i !== index)
     commitArray(newArr)
   }
@@ -82,11 +94,9 @@ export default function ArrayEditor({ fields, data, tabKey, onStructureChange }:
     if (data.length > 0 && data[0] && 'uuid' in data[0]) {
       newItem.uuid = crypto.randomUUID?.() ?? String(Date.now())
     }
+    setIds([...ids, crypto.randomUUID()])
     commitArray([...data, newItem])
   }
-
-  // Generate stable IDs for sortable
-  const ids = data.map((item, i) => (item.id as string) || `item-${i}`)
 
   const handleDragStart = (event: DragStartEvent) => {
     setActiveId(event.active.id as string)

--- a/src/admin/components/KommunalpolitikEditor.tsx
+++ b/src/admin/components/KommunalpolitikEditor.tsx
@@ -76,6 +76,7 @@ export default function KommunalpolitikEditor() {
             onClick={() => update({ sichtbar: !data.sichtbar })}
             className={`shrink-0 transition-colors ${data.sichtbar ? 'text-spd-red' : 'text-gray-300 dark:text-gray-600'}`}
             title={data.sichtbar ? 'Ausblenden' : 'Einblenden'}
+            aria-label={data.sichtbar ? 'Ausblenden' : 'Einblenden'}
           >
             {data.sichtbar ? (
               <ToggleRight size={36} strokeWidth={1.5} />
@@ -147,6 +148,7 @@ export default function KommunalpolitikEditor() {
                     type="button"
                     onClick={() => toggleJahrAktiv(jahr.id)}
                     title={jahr.aktiv ? 'Ausblenden' : 'Einblenden'}
+                    aria-label={jahr.aktiv ? 'Jahr ausblenden' : 'Jahr einblenden'}
                     className={`shrink-0 transition-colors ${jahr.aktiv ? 'text-spd-red' : 'text-gray-300 dark:text-gray-600'}`}
                   >
                     {jahr.aktiv ? (
@@ -176,12 +178,14 @@ export default function KommunalpolitikEditor() {
                     onClick={() => removeJahr(jahr.id)}
                     className="shrink-0 w-7 h-7 flex items-center justify-center rounded-xl text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 transition-all"
                     title="Jahr löschen"
+                    aria-label="Jahr löschen"
                   >
                     <Trash2 size={13} />
                   </button>
                   <button
                     type="button"
                     onClick={() => toggleExpand(jahr.id)}
+                    aria-label={expanded ? 'Jahr einklappen' : 'Jahr ausklappen'}
                     className="shrink-0 w-7 h-7 flex items-center justify-center rounded-xl bg-gray-100 dark:bg-gray-800 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-all"
                   >
                     {expanded ? <ChevronUp size={13} /> : <ChevronDown size={13} />}
@@ -416,6 +420,7 @@ function DokumentRow({
           onClick={onRemove}
           className="shrink-0 w-8 h-8 flex items-center justify-center rounded-xl text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 transition-all"
           title="Entfernen"
+          aria-label="Dokument entfernen"
         >
           <Trash2 size={13} />
         </button>

--- a/src/admin/fields/ImageField.tsx
+++ b/src/admin/fields/ImageField.tsx
@@ -31,18 +31,12 @@ export default function ImageField({ field, value, onChange, contextItem }: Prop
   const [showUrl, setShowUrl] = useState(!value)
   // Track the previous value as state so we can sync derived state when value
   // changes externally (undo / redo / item switch) without accessing a ref during render.
+  // Internal changes (typing in the URL input, crop upload) update prevValue themselves
+  // so this block doesn't hide the URL input or overwrite the local preview mid-edit.
   const [prevValue, setPrevValue] = useState(value)
-  // Tracks the URL of our own pending upload to avoid overwriting its local preview
-  const [ownUploadUrl, setOwnUploadUrl] = useState<string | null>(null)
-
-  // Sync preview and showUrl when value changes externally (undo / redo / item switch)
   if (prevValue !== value) {
     setPrevValue(value)
-    if (value !== ownUploadUrl) {
-      setPreview(resolvePreview(value || ''))
-    } else {
-      setOwnUploadUrl(null)
-    }
+    setPreview(resolvePreview(value || ''))
     setShowUrl(!value)
   }
 
@@ -61,7 +55,7 @@ export default function ImageField({ field, value, onChange, contextItem }: Prop
     const imageDir = field.imageDir || 'news'
     const ghFilePath = `public/images/${imageDir}/${nameSlug}.webp`
     const publicUrl = `/images/${imageDir}/${nameSlug}.webp`
-    setOwnUploadUrl(publicUrl)
+    setPrevValue(publicUrl)
     addPendingUpload({
       ghPath: ghFilePath,
       base64,
@@ -88,6 +82,7 @@ export default function ImageField({ field, value, onChange, contextItem }: Prop
               <button
                 type="button"
                 onClick={() => fileRef.current?.click()}
+                aria-label="Bild ersetzen"
                 className="absolute inset-0 bg-black/0 group-hover:bg-black/40 rounded-2xl transition-all flex items-center justify-center text-transparent group-hover:text-white"
               >
                 <Upload size={18} />
@@ -130,8 +125,9 @@ export default function ImageField({ field, value, onChange, contextItem }: Prop
             autoCapitalize="off"
             autoCorrect="off"
             onChange={e => {
+              setPrevValue(e.target.value)
               onChange(e.target.value)
-              setPreview(e.target.value)
+              setPreview(resolvePreview(e.target.value))
             }}
           />
         )}

--- a/src/admin/fields/ImageListField.tsx
+++ b/src/admin/fields/ImageListField.tsx
@@ -261,6 +261,7 @@ function ImageListItem({
               {...dragListeners}
               className="w-7 h-7 rounded-lg flex items-center justify-center text-gray-300 hover:text-gray-500 dark:text-gray-600 dark:hover:text-gray-400 cursor-grab active:cursor-grabbing transition-colors touch-none"
               title="Ziehen zum Sortieren"
+              aria-label="Ziehen zum Sortieren"
             >
               <GripVertical size={14} />
             </button>
@@ -268,6 +269,7 @@ function ImageListItem({
               type="button"
               disabled={index === 0}
               onClick={onMoveUp}
+              aria-label="Nach oben verschieben"
               className="w-7 h-7 rounded-lg flex items-center justify-center text-gray-400 hover:text-spd-red hover:bg-spd-red/10 disabled:opacity-25 disabled:hover:text-gray-400 disabled:hover:bg-transparent transition-all"
             >
               <ArrowUp size={13} />
@@ -276,6 +278,7 @@ function ImageListItem({
               type="button"
               disabled={index >= total - 1}
               onClick={onMoveDown}
+              aria-label="Nach unten verschieben"
               className="w-7 h-7 rounded-lg flex items-center justify-center text-gray-400 hover:text-spd-red hover:bg-spd-red/10 disabled:opacity-25 disabled:hover:text-gray-400 disabled:hover:bg-transparent transition-all"
             >
               <ArrowDown size={13} />
@@ -293,6 +296,7 @@ function ImageListItem({
           <button
             type="button"
             onClick={() => fileRef.current?.click()}
+            aria-label="Bild hochladen"
             className="w-16 h-16 rounded-xl border-2 border-dashed border-gray-300 dark:border-gray-600 flex items-center justify-center text-gray-400 hover:border-spd-red hover:text-spd-red transition-colors shrink-0"
           >
             <ImagePlus size={16} />


### PR DESCRIPTION
Fixes four issues found in a full review of the admin editor:

- **ImageField:** the manual URL input unmounted after every keystroke — the external-change sync block also ran for the component's own `onChange` calls. Internal changes now update `prevValue` themselves; this also replaces the `ownUploadUrl` workaround and resolves pending-upload previews for manually typed paths. Regression test added with a controlled parent.
- **ArrayEditor:** sortable ids fell back to `item-${index}` for items without an `id` field — the common case (Vorstand, Fraktion, Historie, Impressum, …). Ids now live in component state as stable UUIDs, mutated in tandem with the data, mirroring `ImageListField`.
- **API hardening:** the ICS proxy no longer forwards raw `Error` messages in 502 responses (opaque `upstream_error` code instead); `start`, `callback` and `session` reject non-GET methods with 405, matching `logout`/`refresh`.
- **Accessibility:** added missing German `aria-label`s to icon-only buttons in `KommunalpolitikEditor`, `ImageListField` and `ImageField`.

Pre-push checklist green: build, 902 tests in 40 files, Prettier, knip, unused-assets.

https://claude.ai/code/session_01Pagefo2Wzozfcw7LzNy6zE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pagefo2Wzozfcw7LzNy6zE)_