### PR TITLE
fix(admin): harden GitHub proxy allowlist and enforce no-store on all API paths

### DIFF
--- a/api/auth/logout.ts
+++ b/api/auth/logout.ts
@@ -8,6 +8,8 @@ import { rateLimit, getClientIP } from './rateLimit.js'
  * Revokes the GitHub access token (best-effort) and clears all auth HttpOnly cookies.
  */
 export default async function handler(req: VercelRequest, res: VercelResponse) {
+  res.setHeader('Cache-Control', 'no-store')
+
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'method_not_allowed' })
   }
@@ -49,6 +51,5 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   res.setHeader('Set-Cookie', clearAuthCookies())
-  res.setHeader('Cache-Control', 'no-store')
   return res.status(200).json({ ok: true })
 }

--- a/api/github.ts
+++ b/api/github.ts
@@ -15,12 +15,35 @@ import { parseCookies, isAllowedOrigin, ACCESS_TOKEN_COOKIE } from './auth/cooki
 // (emails, repos, etc.) — only the exact /user identity endpoint is needed.
 const ALLOWED_REPO_PREFIX = '/repos/UgurTheG/SPD-Albstadt/'
 
-function isAllowedPath(path: string): boolean {
-  return (
-    path === '/user' ||
-    path === ALLOWED_REPO_PREFIX.slice(0, -1) ||
-    path.startsWith(ALLOWED_REPO_PREFIX)
-  )
+/**
+ * Resolve the proxied path against the GitHub API origin and validate the
+ * *normalized* pathname. Validating the raw string is unsafe: the URL parser
+ * collapses `..` segments, so a string that passes a naive `startsWith` check
+ * (e.g. `/repos/UgurTheG/SPD-Albstadt/../../../user/emails`) can resolve to a
+ * completely different endpoint. Returns the safe request URL, or null if the
+ * path is not allowed.
+ */
+function resolveAllowedUrl(path: string): string | null {
+  if (typeof path !== 'string' || !path.startsWith('/')) return null
+
+  let resolved: URL
+  try {
+    resolved = new URL(path, 'https://api.github.com')
+  } catch {
+    return null
+  }
+
+  // Reject anything that escaped the api.github.com origin.
+  if (resolved.origin !== 'https://api.github.com') return null
+
+  const pathname = resolved.pathname
+  const allowed =
+    pathname === '/user' ||
+    pathname === ALLOWED_REPO_PREFIX.slice(0, -1) ||
+    pathname.startsWith(ALLOWED_REPO_PREFIX)
+  if (!allowed) return null
+
+  return resolved.toString()
 }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -59,7 +82,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(400).json({ error: 'invalid_method' })
   }
 
-  if (!isAllowedPath(path)) {
+  const requestUrl = resolveAllowedUrl(path)
+  if (!requestUrl) {
     return res.status(400).json({ error: 'path_not_allowed' })
   }
 
@@ -81,7 +105,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       fetchOpts.body = JSON.stringify(body)
     }
 
-    const ghRes = await fetch(`https://api.github.com${path}`, fetchOpts)
+    const ghRes = await fetch(requestUrl, fetchOpts)
 
     // Forward GitHub's status code and body
     const contentType = ghRes.headers.get('content-type') ?? ''

--- a/api/ics.ts
+++ b/api/ics.ts
@@ -22,6 +22,8 @@ function getIcsUrl(): string {
 }
 
 export default async function handler(_req: VercelRequest, res: VercelResponse) {
+  // Never cache proxy responses — error codes and feed contents must always be fresh.
+  res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate')
   // Allow cross-origin requests so the frontend on Hostinger can call this endpoint.
   res.setHeader('Access-Control-Allow-Origin', '*')
   res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
@@ -45,7 +47,6 @@ export default async function handler(_req: VercelRequest, res: VercelResponse) 
     const body = await upstream.text()
 
     res.setHeader('Content-Type', 'text/calendar; charset=utf-8')
-    res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate')
     res.status(200).end(body)
   } catch {
     // Opaque code only — raw error messages can leak internal hostnames/paths


### PR DESCRIPTION
## Summary

Fixes three security/correctness bugs found during an audit of the admin-related serverless API routes.

### 1. GitHub proxy allowlist bypass via path traversal (high)

`api/github.ts` validated the raw request path with a `startsWith` check, then interpolated it directly into the `api.github.com` URL. The URL parser collapses `..` segments, so a path that *passed* the allowlist resolved to a different endpoint:

| Input (passes old allowlist) | Actually requested |
| --- | --- |
| `/repos/UgurTheG/SPD-Albstadt/../../../user/emails` | `/user/emails` |
| `/repos/UgurTheG/SPD-Albstadt/../../OtherOrg/secret/contents` | `/repos/OtherOrg/secret/contents` |

An authenticated caller could reach arbitrary GitHub API endpoints with the server-held token. The path is now resolved against the `api.github.com` origin and the **normalized** pathname (and origin) is validated before fetching.

### 2 & 3. `Cache-Control: no-store` missing on early-return paths (low)

- `api/auth/logout.ts` only set the header after the method/rate-limit/origin guards, so 405/429/403 responses went out without it.
- `api/ics.ts` only set it on the 200 path, leaving the 502 error responses cacheable.

The header is now set at the top of each handler so every response path is covered.

## Testing

- `npm run build` ✅
- `npm run test` ✅ (902 tests)
- `npm run format:check` ✅
- `npm run knip` ✅
- `npm run find-unused-assets` ✅

https://claude.ai/code/session_01QGLQwqrwYjndTg3S5dUWsY

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGLQwqrwYjndTg3S5dUWsY)_