### PR TITLE
fix(admin): resolve data-loss, diff-corruption and accessibility bugs from frontend audit

### DIFF
--- a/src/admin/__tests__/diff.test.ts
+++ b/src/admin/__tests__/diff.test.ts
@@ -172,6 +172,34 @@ describe('diffTab (array type)', () => {
     expect(entries[0].itemIndex).toBe(0)
   })
 
+  it('does not scramble fields when an insert shifts an edited item', () => {
+    const original = [
+      { name: 'Alice', value: 'x' },
+      { name: 'Bob', value: 'y' },
+    ]
+    const current = [
+      { name: 'Neu', value: 'n' },
+      { name: 'Alice', value: 'xx' }, // Alice edited and shifted down by the insert
+      { name: 'Bob', value: 'y' },
+    ]
+    const entries = diffTab(arrayTab, original, current)
+    // No modified entry may pair two different items — that would leak a field
+    // value from the wrong item and corrupt data on revert.
+    expect(entries.every(e => e.kind !== 'modified')).toBe(true)
+    // Reverting any single change must never produce a hybrid item mixing one
+    // item's identity with another item's field value.
+    for (const entry of entries) {
+      const reverted = applyRevert(arrayTab, original, current, entry) as {
+        name: string
+        value: string
+      }[]
+      expect(reverted.some(it => it.name === 'Neu' && it.value !== 'n')).toBe(false)
+      expect(
+        reverted.some(it => it.name === 'Alice' && it.value !== 'x' && it.value !== 'xx'),
+      ).toBe(false)
+    }
+  })
+
   it('still reports a genuine reorder as moved', () => {
     const original = [
       { name: 'Alice', value: 'x' },

--- a/src/admin/__tests__/merge.test.ts
+++ b/src/admin/__tests__/merge.test.ts
@@ -143,6 +143,20 @@ describe('threeWayMerge — arrays with id fields', () => {
     expect(result.find(i => i.id === 2)).toBeUndefined() // Bob removed
   })
 
+  it('we delete an item, they edit it — conflict, their edit preserved (not silently dropped)', () => {
+    const original = [alice, bob]
+    const ours = [alice] // we deleted Bob
+    const theirs = [alice, { ...bob, role: 'superadmin' }] // they edited Bob
+    const { merged, conflicts } = threeWayMerge(original, ours, theirs)
+    const result = merged as typeof ours
+    // A delete-vs-edit is a real conflict — it must surface, not vanish silently.
+    expect(conflicts).toHaveLength(1)
+    expect(conflicts[0].ours).toBeUndefined()
+    expect((conflicts[0].theirs as { role: string }).role).toBe('superadmin')
+    // Their edit is kept in the merged default so no data is lost without a choice.
+    expect(result.find(i => i.id === 2)?.role).toBe('superadmin')
+  })
+
   it('they add a new item, we did not touch array — their addition kept', () => {
     const original = [alice]
     const ours = [alice] // unchanged

--- a/src/admin/__tests__/storeExtended.test.ts
+++ b/src/admin/__tests__/storeExtended.test.ts
@@ -419,6 +419,20 @@ describe('publishSlice — conflict auto-merge retry', () => {
     expect(useAdminStore.getState().statusType).toBe('error')
     expect(useAdminStore.getState().publishing).toBe(false)
   })
+
+  it('advances baseCommitSha when surfacing conflicts so the republish does not re-conflict', async () => {
+    vi.mocked(commitTree).mockRejectedValueOnce(new ConflictError())
+    // Their published version changed the same field differently → real conflict
+    vi.mocked(getFileContent).mockResolvedValue([{ titel: 'theirs' }])
+    await useAdminStore.getState().publishTab('news')
+    const st = useAdminStore.getState()
+    expect(st.mergeConflicts?.length).toBeGreaterThan(0)
+    // Was 'oldsha'; must advance to the fresh branch tip (mocked getBranchSha),
+    // otherwise the post-resolution republish commits against a stale SHA and
+    // conflicts again — collapsing to theirs and discarding the user's choices.
+    expect(st.baseCommitSha).toBe('abc123')
+    expect(st.publishing).toBe(false)
+  })
 })
 
 // ── publishSlice — stale pending uploads ──────────────────────────────────────

--- a/src/admin/components/ConflictMergeModal.tsx
+++ b/src/admin/components/ConflictMergeModal.tsx
@@ -6,7 +6,7 @@
  * with "Keep mine" / "Keep theirs" buttons.  Once all conflicts are resolved
  * the "Veröffentlichen" button becomes available.
  */
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { AlertTriangle, CheckCircle2, GitMerge, User } from 'lucide-react'
 import { motion, AnimatePresence } from 'framer-motion'
 import type { MergeConflict } from '../lib/merge'
@@ -33,6 +33,20 @@ export default function ConflictMergeModal({ tabKey, conflicts, onClose }: Props
 
   // Track which value the user picks for each conflict: 'ours' | 'theirs'
   const [choices, setChoices] = useState<Record<number, 'ours' | 'theirs'>>({})
+
+  // Escape-to-close + body scroll lock, matching the other admin modals.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', handler)
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      window.removeEventListener('keydown', handler)
+      document.body.style.overflow = prevOverflow
+    }
+  }, [onClose])
 
   const allResolved = conflicts.every((_, i) => choices[i] !== undefined)
   const tab = TABS.find(t => t.key === tabKey)

--- a/src/admin/components/FieldRenderer.tsx
+++ b/src/admin/components/FieldRenderer.tsx
@@ -311,6 +311,7 @@ function StringListField({
           />
           <button
             type="button"
+            aria-label="Eintrag entfernen"
             className="text-xs text-gray-300 group-hover:text-red-400 hover:text-red-600! px-2 rounded-lg transition-colors"
             onClick={() => {
               const n = [...list]

--- a/src/admin/components/HaushaltsredenEditor.tsx
+++ b/src/admin/components/HaushaltsredenEditor.tsx
@@ -222,11 +222,15 @@ export default function HaushaltsredenEditor() {
                         >
                           <Eye size={10} /> Ansehen
                         </a>
-                        <label className="text-[10px] font-semibold px-2.5 py-2 rounded-xl bg-gray-100/80 dark:bg-gray-800/60 text-gray-500 hover:bg-gray-200 dark:hover:bg-gray-700 transition-all cursor-pointer flex items-center">
+                        <label
+                          title="PDF ersetzen"
+                          className="text-[10px] font-semibold px-2.5 py-2 rounded-xl bg-gray-100/80 dark:bg-gray-800/60 text-gray-500 hover:bg-gray-200 dark:hover:bg-gray-700 transition-all cursor-pointer flex items-center"
+                        >
                           <RefreshCw size={10} />
                           <input
                             type="file"
                             accept=".pdf"
+                            aria-label={`PDF für ${year} ersetzen`}
                             className="hidden"
                             onChange={e => {
                               if (e.target.files?.[0]) uploadPdf(year, e.target.files[0])
@@ -236,6 +240,7 @@ export default function HaushaltsredenEditor() {
                         <button
                           type="button"
                           onClick={() => requestDelete(year)}
+                          aria-label={`PDF für ${year} löschen`}
                           className="text-[10px] font-semibold px-2.5 py-2 rounded-xl bg-red-50/80 dark:bg-red-900/15 text-red-400 hover:bg-red-100 dark:hover:bg-red-900/30 transition-all"
                         >
                           <Trash2 size={10} />

--- a/src/admin/components/ItemCardBody.tsx
+++ b/src/admin/components/ItemCardBody.tsx
@@ -56,6 +56,7 @@ export default function ItemCardBody({
             <button
               type="button"
               onClick={() => onMove(index, index - 1)}
+              aria-label="Nach oben verschieben"
               className="w-7 h-7 sm:w-8 sm:h-8 flex items-center justify-center rounded-xl bg-gray-100/80 dark:bg-gray-800/60 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-200/80 dark:hover:bg-gray-700 transition-all"
             >
               <ChevronUp size={14} />
@@ -65,6 +66,7 @@ export default function ItemCardBody({
             <button
               type="button"
               onClick={() => onMove(index, index + 1)}
+              aria-label="Nach unten verschieben"
               className="w-7 h-7 sm:w-8 sm:h-8 flex items-center justify-center rounded-xl bg-gray-100/80 dark:bg-gray-800/60 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-200/80 dark:hover:bg-gray-700 transition-all"
             >
               <ChevronDown size={14} />
@@ -73,6 +75,7 @@ export default function ItemCardBody({
           <button
             type="button"
             onClick={onRemove}
+            aria-label="Entfernen"
             className="h-7 sm:h-8 bg-red-50/80 dark:bg-red-900/15 text-red-500 hover:bg-red-100 dark:hover:bg-red-900/30 px-2 sm:px-3 rounded-xl transition-all text-[10px] sm:text-xs font-medium flex items-center gap-1 sm:gap-1.5 ml-0.5 sm:ml-1"
           >
             <Trash2 size={12} /> <span className="hidden sm:inline">Entfernen</span>

--- a/src/admin/components/ModalFrame.tsx
+++ b/src/admin/components/ModalFrame.tsx
@@ -53,6 +53,7 @@ export default function ModalFrame({
           <button
             type="button"
             onClick={onClose}
+            aria-label="Schließen"
             className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 w-8 h-8 rounded-xl hover:bg-gray-100 dark:hover:bg-gray-800 flex items-center justify-center transition-colors"
           >
             <X size={16} />

--- a/src/admin/components/PreviewModal.tsx
+++ b/src/admin/components/PreviewModal.tsx
@@ -125,6 +125,7 @@ export default function PreviewModal({ tabKey, onClose }: Props) {
           <button
             type="button"
             onClick={onClose}
+            aria-label="Schließen"
             className="w-9 h-9 rounded-xl bg-gray-800 hover:bg-gray-700 flex items-center justify-center text-gray-400 hover:text-white transition-colors"
           >
             <X size={16} />

--- a/src/admin/fields/IconPickerField.tsx
+++ b/src/admin/fields/IconPickerField.tsx
@@ -21,10 +21,14 @@ export default function IconPickerField({ id, value, onChange }: Props) {
   const [pos, setPos] = useState({ top: 0, left: 0, width: 0 })
 
   useEffect(() => {
-    if (value)
-      loadIconSvg(value).then(svg => {
-        if (svg) setSvgHtml(svg)
-      })
+    if (!value) return
+    let active = true
+    loadIconSvg(value).then(svg => {
+      if (active && svg) setSvgHtml(svg)
+    })
+    return () => {
+      active = false
+    }
   }, [value])
 
   useEffect(() => {
@@ -131,9 +135,13 @@ function IconCell({
 }) {
   const [svg, setSvg] = useState('')
   useEffect(() => {
+    let active = true
     loadIconSvg(name).then(s => {
-      if (s) setSvg(s)
+      if (active && s) setSvg(s)
     })
+    return () => {
+      active = false
+    }
   }, [name])
   return (
     <button

--- a/src/admin/lib/diff.ts
+++ b/src/admin/lib/diff.ts
@@ -60,6 +60,51 @@ function itemLabel(
   return `#${fallbackIndex + 1}`
 }
 
+/** A stable identity for an array item, or undefined when none can be derived.
+ *  Mirrors itemLabel's preference order but never falls back to the index. */
+function stableIdentity(
+  fields: FieldConfig[],
+  item: Record<string, unknown> | undefined,
+): string | undefined {
+  if (!item) return undefined
+  const byKey = (k: string) =>
+    typeof item[k] === 'string' && (item[k] as string).trim()
+      ? (item[k] as string).trim()
+      : undefined
+  const preferred = byKey('name') || byKey('titel') || byKey('jahr')
+  if (preferred) return preferred
+  for (const f of fields) {
+    if (f.type === 'text' || f.type === 'email' || f.type === 'url') {
+      const v = byKey(f.key)
+      if (v) return v
+    }
+  }
+  return undefined
+}
+
+/**
+ * Whether two array items at the same index represent the same logical item
+ * (edited in place) rather than two different items that happen to share a slot
+ * after an insert/remove shifted positions.
+ *
+ * Positional field-diff pairing is only safe for same-index items because
+ * applyRevert reads the original and writes the current value at one shared
+ * path index. Pairing two genuinely different items would leak field values
+ * between them on revert, so we gate it on identity (then on field similarity
+ * for items that carry no stable identity field).
+ */
+function isSameItem(
+  fields: FieldConfig[],
+  o: Record<string, unknown> | undefined,
+  c: Record<string, unknown> | undefined,
+): boolean {
+  if (!o || !c) return false
+  const io = stableIdentity(fields, o)
+  const ic = stableIdentity(fields, c)
+  if (io !== undefined && ic !== undefined) return io === ic
+  return fields.some(f => eq(o[f.key], c[f.key]))
+}
+
 function diffFields(
   fields: FieldConfig[],
   original: Record<string, unknown> | undefined,
@@ -214,6 +259,10 @@ function diffArray(
     if (origUsed.has(i)) continue // original item lives on at another index
     const o = orig[i] as Record<string, unknown> | undefined
     const c = curr[i] as Record<string, unknown> | undefined
+    // Only field-diff when both slots hold the same logical item. Otherwise an
+    // insert/remove has shifted positions and these are different items — leave
+    // them to the added/removed passes so revert never mixes their fields.
+    if (!isSameItem(fields, o, c)) continue
     origPaired.add(i)
     currPaired.add(i)
     diffFields(fields, o, c, [...basePath, i], group, groupKey, i, itemLabel(fields, c, i), out)

--- a/src/admin/lib/merge.ts
+++ b/src/admin/lib/merge.ts
@@ -153,10 +153,22 @@ function mergeArraysById(
 
     if (!ourItem) {
       // We deleted this item; theirs still has it.
-      // If we explicitly removed it (it was in original), keep deletion.
-      // If it was never in original (they added it), keep theirs'.
-      if (!orig) result.push(theirItem) // new item added by them
-      // else: we deleted it — omit (our delete wins)
+      if (!orig) {
+        result.push(theirItem) // new item added by them — keep it
+      } else if (!deepEq(orig, theirItem)) {
+        // Delete-vs-edit: we removed it but they changed it. This is a real
+        // conflict — surface it instead of silently dropping their edit. We keep
+        // their version in the merged result (the modal default) and let the user
+        // choose to re-delete it via "Meine Version".
+        conflicts.push({
+          path: [...path, String(id)],
+          label: pathLabel([...path, String(id)]),
+          ours: undefined,
+          theirs: theirItem,
+        })
+        result.push(theirItem)
+      }
+      // else: they didn't touch it — our delete wins (omit)
     } else {
       // Both sides have it — recursively merge the object
       const base = orig ?? ({} as IdObject)

--- a/src/admin/store/editorSlice.ts
+++ b/src/admin/store/editorSlice.ts
@@ -272,6 +272,8 @@ export const createEditorSlice: StateCreator<AdminState, [], [], EditorSlice> = 
         redoStacks: { ...prev.redoStacks, [tabKey]: [] },
       }
     })
+    // Reset the debounce clock so the first edit after a revert is undoable.
+    lastUndoPush[tabKey] = 0
     persistPendingUploads(keptForPersist)
     get().setStatus('Änderungen verworfen.', 'info')
   },

--- a/src/admin/store/persistence.ts
+++ b/src/admin/store/persistence.ts
@@ -126,6 +126,12 @@ export function restoreDrafts(
  * or explicit reset). Uses the same DRAFT_KEY as persistDirtyState.
  */
 export function removeDraft(tabKey: string) {
+  // Cancel any in-flight debounced write — its closure captured the pre-publish
+  // state and would otherwise resurrect the draft we are about to remove.
+  if (saveTimer) {
+    clearTimeout(saveTimer)
+    saveTimer = null
+  }
   try {
     const raw = localStorage.getItem(DRAFT_KEY)
     if (!raw) return

--- a/src/admin/store/publishSlice.ts
+++ b/src/admin/store/publishSlice.ts
@@ -133,10 +133,18 @@ export const createPublishSlice: StateCreator<AdminState, [], [], PublishSlice> 
                 await get().publishTab(tabKey, orphansToDelete, true)
                 return
               } else {
-                // Conflicts — surface merge modal with partially-merged draft
+                // Conflicts — surface merge modal with partially-merged draft.
+                // Advance baseCommitSha to the fresh tip (mirroring the clean-merge
+                // branch) so the republish after manual resolution commits against
+                // the current remote instead of conflicting again — a second conflict
+                // would collapse threeWayMerge(resolved, resolved, theirs) to `theirs`
+                // and silently discard the user's choices.
                 get().updateState(tabKey, merged)
+                const { getBranchSha } = await import('../lib/github')
+                const freshSha = await getBranchSha()
                 set(prev => ({
                   originalState: { ...prev.originalState, [tabKey]: latest },
+                  baseCommitSha: freshSha,
                   mergeConflicts: conflicts,
                   mergeConflictTabKey: tabKey,
                 }))


### PR DESCRIPTION
## Summary

Fixes the bugs found in a frontend audit of the admin editor (store, lib, components). Grouped by severity.

### 🔴 High — data loss / corruption

**1. Conflict resolution discarded the editor's manual choices** (`store/publishSlice.ts`)
The conflicts branch of `publishTab` updated `originalState` to the remote version but left `baseCommitSha` stale (the clean-merge branch advances it). After the user resolved conflicts, the republish committed against the old SHA → conflicted again → `threeWayMerge(resolved, resolved, theirs)` collapsed to `theirs` because `original === ours`, silently overwriting every "Meine Version" choice. Now the conflicts branch advances `baseCommitSha` to the fresh tip.

**2. Array diff scrambled fields and corrupted selective revert** (`lib/diff.ts`)
`diffArray` paired leftover items by raw index, so an insert/removal that shifted positions while another item was edited mislabeled the diff and leaked field values between items on revert. Now field-diffing of same-index slots only happens when they hold the same logical item (identity via name/titel/jahr, then field similarity); otherwise items fall through to the added/removed passes.

### 🟡 Medium

**3. Delete-vs-edit silently dropped the other user's edit** (`lib/merge.ts`) — now surfaced as a real conflict, their edit kept as the merged default.

**4. Missing German `aria-label`s on icon-only buttons** (`ModalFrame`, `ItemCardBody`, `FieldRenderer`, `HaushaltsredenEditor`, `PreviewModal`) — per the project accessibility rule.

**5. `ConflictMergeModal` had no Escape-to-close and no body scroll lock** — added, matching the other admin modals.

**6. Stale debounced draft write after publish** (`store/persistence.ts`) — `removeDraft` now cancels the pending timer so a publish no longer resurrects the just-removed draft.

### 🟢 Low
- Reset the undo debounce clock after a revert so the first post-revert edit is individually undoable.
- Guard the icon-picker async `setState` against firing after unmount.

The `eq`/`deepEq` `JSON.stringify` key-ordering observation was intentionally left as-is — it was not reproducible and changing equality semantics carries more risk than benefit.

## Testing

Added tests for the conflict `baseCommitSha` advance, the non-corrupting insert+edit diff, and the delete-vs-edit merge conflict.

- `npm run build` ✅
- `npm run test` ✅ (905 tests)
- `npm run format:check` ✅
- `npm run knip` ✅
- `npm run find-unused-assets` ✅

https://claude.ai/code/session_01QGLQwqrwYjndTg3S5dUWsY

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGLQwqrwYjndTg3S5dUWsY)_