### PR TITLE
Configure Renovate to group all updates into a single PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,47 +7,15 @@
   "automerge": true,
   "automergeType": "pr",
   "automergeStrategy": "squash",
+  "separateMajorMinor": false,
   "major": {
     "automerge": false
   },
   "packageRules": [
     {
-      "groupName": "react",
-      "matchPackageNames": [
-        "react",
-        "react-dom",
-        "react-router-dom",
-        "@types/react",
-        "@types/react-dom"
-      ]
-    },
-    {
-      "groupName": "tailwind",
-      "matchPackageNames": ["/^tailwindcss/", "/^@tailwindcss\\//"]
-    },
-    {
-      "groupName": "framer-motion",
-      "matchPackageNames": ["framer-motion"]
-    },
-    {
-      "groupName": "dnd-kit",
-      "matchPackageNames": ["/^@dnd-kit\\//"]
-    },
-    {
-      "groupName": "eslint",
-      "matchPackageNames": ["/^eslint/", "/^@eslint\\//", "/^typescript-eslint/"]
-    },
-    {
-      "groupName": "vite",
-      "matchPackageNames": ["/^vite/", "/^@vitejs\\//"]
-    },
-    {
-      "groupName": "typescript",
-      "matchPackageNames": ["/^typescript/", "/^@types\\//"]
-    },
-    {
-      "groupName": "github-actions",
-      "matchManagers": ["github-actions"]
+      "groupName": "all dependencies",
+      "groupSlug": "all",
+      "matchPackageNames": ["*"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Renovate previously opened several grouped PRs per run (react, tailwind, eslint, vite, typescript, dnd-kit, framer-motion, github-actions). This consolidates everything into a **single** weekly update PR.

## Changes

- Replaced the per-library `packageRules` groups with one rule matching all packages (`"matchPackageNames": ["*"]`, `groupName: "all dependencies"`).
- Added `"separateMajorMinor": false` so major updates join the same PR instead of getting their own — guaranteeing exactly one PR per run.

## Notes

- Automerge still applies to patch/minor-only PRs. Because `major.automerge` remains `false`, any PR containing a major bump will wait for manual review.
- Weekly schedule (Mon before 9am, Europe/Berlin) is unchanged.

https://claude.ai/code/session_01KKra2bDAkGu2QyaBaJvVKG

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKra2bDAkGu2QyaBaJvVKG)_