### PR TITLE
Split major dependency updates out of the grouped Renovate PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
   "automerge": true,
   "automergeType": "pr",
   "automergeStrategy": "squash",
-  "separateMajorMinor": false,
+  "separateMajorMinor": true,
   "major": {
     "automerge": false
   },


### PR DESCRIPTION
## Problem

The weekly Renovate PR (`renovate/all`, currently #111) never auto-merges even though all checks pass. The config groups every package into one PR (`matchPackageNames: ["*"]`) with `separateMajorMinor: false`, so a single pending **major** update — currently `actions/checkout v6 → v7` — gets bundled with all the minor/patch bumps. The grouped PR then inherits `major.automerge: false` for the whole batch, blocking automerge for everything behind one major.

## Change

Set `separateMajorMinor: true` in `renovate.json`. Renovate now splits major updates into their own PR (which still requires manual approval via `major.automerge: false`), while the grouped minor/patch PR can automerge again.

## Note on the empty Monday run

Separately, the schedule `before 9am on Monday` only acts within a 00:00–09:00 window; Mend runs landing later in the day just re-render the dashboard without touching branches. Not changed here, but worth widening if weekly runs keep missing the window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGyAWkzGN79P81cEF1VX8k)_